### PR TITLE
Archive serenity reports

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -41,8 +41,16 @@ withPipeline(type , product, component) {
         env.ITEST_ENVIRONMENT = "aat"
     }
 
+    after('functionalTest:aat') {
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
+    }
+    
     before('functionalTest:preview') {
         env.ITEST_ENVIRONMENT = "preview"
+    }
+
+    after('functionalTest:preview') {
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     }
 
     after('checkout') {


### PR DESCRIPTION
# Description

Aggregate Serenity Reports are being generated but not archived by Jenkins, so they are not accessible. This code tells Jenkins to archive the serenity outputs after the functional test finishes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

No tests required as long as Serenity Reports can be seen after the preview build finishes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
