### PR TITLE
Migrate to CNP Draft Store & Archive serenity reports

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -41,8 +41,16 @@ withPipeline(type , product, component) {
         env.ITEST_ENVIRONMENT = "aat"
     }
 
+    after('functionalTest:aat') {
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
+    }
+    
     before('functionalTest:preview') {
         env.ITEST_ENVIRONMENT = "preview"
+    }
+
+    after('functionalTest:preview') {
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     }
 
     after('checkout') {

--- a/automation-test/src/test/resources/application-aat.properties
+++ b/automation-test/src/test/resources/application-aat.properties
@@ -1,5 +1,5 @@
 ccd.caseDataStore.baseUrl=http://ccd-data-store-api-aat.service.core-compute-aat.internal
 
-draft.store.api.baseUrl=http://draft-store-service-aat.service.core-compute-saat.internal/
+draft.store.api.baseUrl=${draft.store.api.baseUrl}
 
 auth.idam.client.baseUrl=https://preprod-idamapi.reform.hmcts.net:3511

--- a/automation-test/src/test/resources/application-aat.properties
+++ b/automation-test/src/test/resources/application-aat.properties
@@ -1,5 +1,3 @@
 ccd.caseDataStore.baseUrl=http://ccd-data-store-api-aat.service.core-compute-aat.internal
 
-draft.store.api.baseUrl=${draft.store.api.baseUrl}
-
 auth.idam.client.baseUrl=https://preprod-idamapi.reform.hmcts.net:3511

--- a/automation-test/src/test/resources/application-aat.properties
+++ b/automation-test/src/test/resources/application-aat.properties
@@ -1,5 +1,5 @@
 ccd.caseDataStore.baseUrl=http://ccd-data-store-api-aat.service.core-compute-aat.internal
 
-draft.store.api.baseUrl=https://preproddraftstorelb.moneyclaim.reform.hmcts.net:4301
+draft.store.api.baseUrl=http://draft-store-service-aat.service.core-compute-saat.internal/
 
 auth.idam.client.baseUrl=https://preprod-idamapi.reform.hmcts.net:3511

--- a/automation-test/src/test/resources/application-preview.properties
+++ b/automation-test/src/test/resources/application-preview.properties
@@ -1,6 +1,6 @@
 ccd.caseDataStore.baseUrl=http://ccd-data-store-api-aat.service.core-compute-aat.internal
 
-draft.store.api.baseUrl=http://draft-store-service-aat.service.core-compute-saat.internal/
+draft.store.api.baseUrl=${draft.store.api.baseUrl}
 
 auth.idam.client.baseUrl=https://preprod-idamapi.reform.hmcts.net:3511
 

--- a/automation-test/src/test/resources/application-preview.properties
+++ b/automation-test/src/test/resources/application-preview.properties
@@ -1,6 +1,6 @@
 ccd.caseDataStore.baseUrl=http://ccd-data-store-api-aat.service.core-compute-aat.internal
 
-draft.store.api.baseUrl=https://preproddraftstorelb.moneyclaim.reform.hmcts.net:4301
+draft.store.api.baseUrl=http://draft-store-service-aat.service.core-compute-saat.internal/
 
 auth.idam.client.baseUrl=https://preprod-idamapi.reform.hmcts.net:3511
 

--- a/automation-test/src/test/resources/application-preview.properties
+++ b/automation-test/src/test/resources/application-preview.properties
@@ -1,7 +1,5 @@
 ccd.caseDataStore.baseUrl=http://ccd-data-store-api-aat.service.core-compute-aat.internal
 
-draft.store.api.baseUrl=${draft.store.api.baseUrl}
-
 auth.idam.client.baseUrl=https://preprod-idamapi.reform.hmcts.net:3511
 
 auth.provider.service.client.baseUrl=http://rpe-service-auth-provider-aat.service.core-compute-aat.internal

--- a/automation-test/src/test/resources/application.properties
+++ b/automation-test/src/test/resources/application.properties
@@ -35,7 +35,7 @@ ccd.submit.event=${ccd.caseDataStore.baseUrl}/caseworkers/%d/jurisdictions/DIVOR
 
 drafts.api.url=${transformation.api.url}/draftsapi/version/1
 
-draft.store.api.baseUrl=http://localhost:4601
+draft.store.api.baseUrl=${draft_store_service_url:http://localhost:4601}
 draft.store.api.encryption.key=integration_tests
 draft.store.api.encryption.key.template=%s_%s
 draft.store.api.document.type=divorcedraft

--- a/automation-test/src/test/resources/application.properties
+++ b/automation-test/src/test/resources/application.properties
@@ -33,8 +33,6 @@ ccd.retrieve.case.url=${ccd.caseDataStore.baseUrl}/caseworkers/%d/jurisdictions/
 ccd.create.event=${ccd.caseDataStore.baseUrl}/caseworkers/%d/jurisdictions/DIVORCE/case-types/DIVORCE/cases/%d/event-triggers/%s/token?ignore-warning=true
 ccd.submit.event=${ccd.caseDataStore.baseUrl}/caseworkers/%d/jurisdictions/DIVORCE/case-types/DIVORCE/cases/%d/events?ignore-warning=true
 
-
-
 drafts.api.url=${transformation.api.url}/draftsapi/version/1
 
 draft.store.api.baseUrl=http://localhost:4601

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -2,7 +2,6 @@ vault_env = "preprod"
 
 logging_level_org_springframework_web = "DEBUG"
 logging_level_uk_gov_hmcts_ccd = "DEBUG"
-draft_store_api_baseurl = "https://preproddraftstorelb.moneyclaim.reform.hmcts.net:4301"
 uk_gov_notify_email_templates = "{SAVE_DRAFT:'14074c06-87f1-4678-9238-4d71e741eb57'}"
 uk_gov_notify_email_template_vars = "{SAVE_DRAFT: {divorceUrl: 'https://div-pfe-aat.service.core-compute-aat.internal'}}"
 idam_api_baseurl = "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -2,7 +2,6 @@ vault_env = "preprod"
 
 logging_level_org_springframework_web = "DEBUG"
 logging_level_uk_gov_hmcts_ccd = "DEBUG"
-draft_store_api_baseurl = "https://preproddraftstorelb.moneyclaim.reform.hmcts.net:4301"
 uk_gov_notify_email_templates = "{SAVE_DRAFT:'14074c06-87f1-4678-9238-4d71e741eb57'}"
 uk_gov_notify_email_template_vars = "{SAVE_DRAFT: {divorceUrl: 'https://www.apply-divorce.demo.platform.hmcts.net'}}"
 idam_api_baseurl = "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -49,7 +49,7 @@ module "div-case-progression" {
         PDF_GENERATOR_HEALTHURL = "${local.pdf_generator_base_url}/health"
         DRAFT_STORE_API_ENCRYPTION_KEY = "${data.vault_generic_secret.draft-store-api-encryption-key.data["value"]}"
         DRAFT_STORE_API_BASEURL = "${local.draftstore_api_baseurl}"
-        DRAFT_STORE_API_HEALTH_URI = "${var.draft_store_api_baseurl}/health"
+        DRAFT_STORE_API_HEALTH_URI = "${local.draftstore_api_baseurl}/health"
         UK_GOV_NOTIFY_API_KEY = "${data.vault_generic_secret.uk-gov-notify-api-key.data["value"]}"
         UK_GOV_NOTIFY_EMAIL_TEMPLATES = "${var.uk_gov_notify_email_templates}"
         UK_GOV_NOTIFY_EMAIL_TEMPLATE_VARS = "${var.uk_gov_notify_email_template_vars}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -5,6 +5,7 @@ locals {
 
     pdf_generator_base_url = "http://div-dgs-${local.local_env}.service.core-compute-${local.local_env}.internal"
     ccd_casedatastore_baseurl = "http://ccd-data-store-api-${local.local_env}.service.core-compute-${local.local_env}.internal"
+    draftstore_api_baseurl = "http://draft-store-service-${local.local_env}.service.core-compute-${local.local_env}.internal"
     dm_store_url = "http://dm-store-${local.local_env}.service.core-compute-${local.local_env}.internal"
     idam_s2s_url = "http://${var.idam_s2s_url_prefix}-${local.local_env}.service.core-compute-${local.local_env}.internal"
 
@@ -47,7 +48,7 @@ module "div-case-progression" {
         PDF_GENERATOR_BASE_URL = "${local.pdf_generator_base_url}"
         PDF_GENERATOR_HEALTHURL = "${local.pdf_generator_base_url}/health"
         DRAFT_STORE_API_ENCRYPTION_KEY = "${data.vault_generic_secret.draft-store-api-encryption-key.data["value"]}"
-        DRAFT_STORE_API_BASEURL = "${var.draft_store_api_baseurl}"
+        DRAFT_STORE_API_BASEURL = "${local.draftstore_api_baseurl}"
         DRAFT_STORE_API_HEALTH_URI = "${var.draft_store_api_baseurl}/health"
         UK_GOV_NOTIFY_API_KEY = "${data.vault_generic_secret.uk-gov-notify-api-key.data["value"]}"
         UK_GOV_NOTIFY_EMAIL_TEMPLATES = "${var.uk_gov_notify_email_templates}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -5,7 +5,7 @@ locals {
 
     pdf_generator_base_url = "http://div-dgs-${local.local_env}.service.core-compute-${local.local_env}.internal"
     ccd_casedatastore_baseurl = "http://ccd-data-store-api-${local.local_env}.service.core-compute-${local.local_env}.internal"
-    draftstore_api_baseurl = "http://draft-store-service-${local.local_env}.service.core-compute-${local.local_env}.internal"
+    draft_store_api_baseurl = "http://draft-store-service-${local.local_env}.service.core-compute-${local.local_env}.internal"
     dm_store_url = "http://dm-store-${local.local_env}.service.core-compute-${local.local_env}.internal"
     idam_s2s_url = "http://${var.idam_s2s_url_prefix}-${local.local_env}.service.core-compute-${local.local_env}.internal"
 
@@ -48,8 +48,8 @@ module "div-case-progression" {
         PDF_GENERATOR_BASE_URL = "${local.pdf_generator_base_url}"
         PDF_GENERATOR_HEALTHURL = "${local.pdf_generator_base_url}/health"
         DRAFT_STORE_API_ENCRYPTION_KEY = "${data.vault_generic_secret.draft-store-api-encryption-key.data["value"]}"
-        DRAFT_STORE_API_BASEURL = "${local.draftstore_api_baseurl}"
-        DRAFT_STORE_API_HEALTH_URI = "${local.draftstore_api_baseurl}/health"
+        DRAFT_STORE_API_BASEURL = "${local.draft_store_api_baseurl}"
+        DRAFT_STORE_API_HEALTH_URI = "${local.draft_store_api_baseurl}/health"
         UK_GOV_NOTIFY_API_KEY = "${data.vault_generic_secret.uk-gov-notify-api-key.data["value"]}"
         UK_GOV_NOTIFY_EMAIL_TEMPLATES = "${var.uk_gov_notify_email_templates}"
         UK_GOV_NOTIFY_EMAIL_TEMPLATE_VARS = "${var.uk_gov_notify_email_template_vars}"

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,15 +1,15 @@
 output "vaultName" {
-  value = "${local.vaultName}"
+    value = "${local.vaultName}"
 }
 
 output "vaultUri" {
-  value = "${local.vaultUri}"
+    value = "${local.vaultUri}"
 }
 
 output "idam_s2s_url" {
-  value = "http://${var.idam_s2s_url_prefix}-${var.env}.service.${local.ase_name}.internal"
+    value = "http://${var.idam_s2s_url_prefix}-${var.env}.service.${local.ase_name}.internal"
 }
 
 output "draft_store_service_url" {
-    value = "http://draft-store-service-${local.local_env}.service.core-compute-${local.local_env}.internal"
+    value = "${local.draft_store_api_baseurl}"
 }

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -9,3 +9,7 @@ output "vaultUri" {
 output "idam_s2s_url" {
   value = "http://${var.idam_s2s_url_prefix}-${var.env}.service.${local.ase_name}.internal"
 }
+
+output "draft_store_service_url" {
+    value = "http://draft-store-service-${local.local_env}.service.core-compute-${local.local_env}.internal"
+}

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -2,7 +2,6 @@ vault_env = "preprod"
 
 logging_level_org_springframework_web = "DEBUG"
 logging_level_uk_gov_hmcts_ccd = "DEBUG"
-draft_store_api_baseurl = "https://preproddraftstorelb.moneyclaim.reform.hmcts.net:4301"
 uk_gov_notify_email_templates = "{SAVE_DRAFT:'14074c06-87f1-4678-9238-4d71e741eb57'}"
 uk_gov_notify_email_template_vars = "{SAVE_DRAFT: {divorceUrl: 'https://div-pfe-aat.service.core-compute-aat.internal'}}"
 idam_api_baseurl = "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -2,7 +2,6 @@ vault_env = "prod"
 
 logging_level_org_springframework_web = "INFO"
 logging_level_uk_gov_hmcts_ccd = "INFO"
-draft_store_api_baseurl = "https://proddraftstorelb.moneyclaim.reform.hmcts.net:4301"
 uk_gov_notify_email_templates = "{SAVE_DRAFT:'14074c06-87f1-4678-9238-4d71e741eb57'}"
 uk_gov_notify_email_template_vars = "{SAVE_DRAFT: {divorceUrl: 'https://www.apply-divorce.service.gov.uk'}}"
 idam_api_baseurl = "https://prod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/saat.tfvars
+++ b/infrastructure/saat.tfvars
@@ -2,7 +2,6 @@ vault_env = "test"
 
 logging_level_org_springframework_web = "DEBUG"
 logging_level_uk_gov_hmcts_ccd = "DEBUG"
-draft_store_api_baseurl = "https://testdraftstorelb.moneyclaim.reform.hmcts.net:4302"
 uk_gov_notify_email_templates = "{SAVE_DRAFT:'14074c06-87f1-4678-9238-4d71e741eb57'}"
 uk_gov_notify_email_template_vars = "{SAVE_DRAFT: {divorceUrl: 'https://div-pfe-saat.service.core-compute-saat.internal'}}"
 idam_api_baseurl = "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -2,7 +2,6 @@ vault_env = "test"
 
 logging_level_org_springframework_web = "DEBUG"
 logging_level_uk_gov_hmcts_ccd = "DEBUG"
-draft_store_api_baseurl = "https://testdraftstorelb.moneyclaim.reform.hmcts.net:4302"
 uk_gov_notify_email_templates = "{SAVE_DRAFT:'14074c06-87f1-4678-9238-4d71e741eb57'}"
 uk_gov_notify_email_template_vars = "{SAVE_DRAFT: {divorceUrl: 'https://div-pfe-sandbox.service.core-compute-sandbox.internal'}}"
 idam_api_baseurl = "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -66,10 +66,6 @@ variable "logging_level_uk_gov_hmcts_ccd" {
     type = "string"
 }
 
-variable "draft_store_api_baseurl" {
-    type = "string"
-}
-
 variable "uk_gov_notify_email_templates" {
     type = "string"
 }


### PR DESCRIPTION
# Description

Combined my changes (DIV-2725) with Tonys' PR #42 
- Archive serenity reports & Migrate to CNP Draft Store for all envs

- Simply updated draftstore baseurl to point to new CNP url rather than pointing to tactical. 
- Aggregate Serenity Reports are being generated but not archived by Jenkins, so they are not accessible. This code tells Jenkins to archive the serenity outputs after the functional test finishes.

No tests are required as mine is an infra change and for Tonys changes, no tests are required as long as Serenity Reports can be seen after the preview build finishes.


## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
