### PR TITLE
Changed all dummy email@email.com to use a divorce test email account

### DIFF
--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/additional-payment.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/additional-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/additional-payment.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/additional-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "email@email.com",
+    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/additional-payment.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/additional-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/addresses.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/addresses.json
@@ -38,7 +38,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/addresses.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/addresses.json
@@ -38,7 +38,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/addresses.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/addresses.json
@@ -38,7 +38,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/casedata-d8-payload.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/casedata-d8-payload.json
@@ -91,7 +91,7 @@
     "D8ResidualJurisdictionEligible": "YES",
     "D8DerivedRespondentCurrentName": "Jane Jamed",
     "D8ReasonForDivorceLimitReasons": "NO",
-    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8ReasonForDivorceBehaviourDetails": "My wife is having an affair this week.",
     "D8ReasonForDivorceClaiming5YearSeparatio": "NO",
     "D8DivorceUnit": "eastMidlands",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/casedata-d8-payload.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/casedata-d8-payload.json
@@ -91,7 +91,7 @@
     "D8ResidualJurisdictionEligible": "YES",
     "D8DerivedRespondentCurrentName": "Jane Jamed",
     "D8ReasonForDivorceLimitReasons": "NO",
-    "D8PetitionerEmail": "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
     "D8ReasonForDivorceBehaviourDetails": "My wife is having an affair this week.",
     "D8ReasonForDivorceClaiming5YearSeparatio": "NO",
     "D8DivorceUnit": "eastMidlands",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/casedata-d8-payload.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/casedata-d8-payload.json
@@ -91,7 +91,7 @@
     "D8ResidualJurisdictionEligible": "YES",
     "D8DerivedRespondentCurrentName": "Jane Jamed",
     "D8ReasonForDivorceLimitReasons": "NO",
-    "D8PetitionerEmail": "email@email.com",
+    "D8PetitionerEmail": "divorce.reform.hmcts@gmail.com",
     "D8ReasonForDivorceBehaviourDetails": "My wife is having an affair this week.",
     "D8ReasonForDivorceClaiming5YearSeparatio": "NO",
     "D8DivorceUnit": "eastMidlands",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/ccd-callback-petition-issued.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/ccd-callback-petition-issued.json
@@ -12,7 +12,7 @@
       "D8MarriageIsSameSexCouple": "YES",
       "D8MarriageDate": "2001-02-02",
       "D8PetitionerNameDifferentToMarriageCert": "YES",
-      "D8PetitionerEmail": "email@email.com",
+      "D8PetitionerEmail": "divorce.reform.hmcts@gmail.com",
       "D8PetitionerPhoneNumber": "01234567890",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/ccd-callback-petition-issued.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/ccd-callback-petition-issued.json
@@ -12,7 +12,7 @@
       "D8MarriageIsSameSexCouple": "YES",
       "D8MarriageDate": "2001-02-02",
       "D8PetitionerNameDifferentToMarriageCert": "YES",
-      "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+      "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
       "D8PetitionerPhoneNumber": "01234567890",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/ccd-callback-petition-issued.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/ccd-callback-petition-issued.json
@@ -12,7 +12,7 @@
       "D8MarriageIsSameSexCouple": "YES",
       "D8MarriageDate": "2001-02-02",
       "D8PetitionerNameDifferentToMarriageCert": "YES",
-      "D8PetitionerEmail": "divorce.reform.hmcts@gmail.com",
+      "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
       "D8PetitionerPhoneNumber": "01234567890",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/d8-document.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/d8-document.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/d8-document.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/d8-document.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "email@email.com",
+    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/d8-document.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/d8-document.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/how-name-changed.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/how-name-changed.json
@@ -44,7 +44,7 @@
     "deedPoll",
     "other"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/how-name-changed.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/how-name-changed.json
@@ -44,7 +44,7 @@
     "deedPoll",
     "other"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/how-name-changed.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/how-name-changed.json
@@ -44,7 +44,7 @@
     "deedPoll",
     "other"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-6-12.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-6-12.json
@@ -42,7 +42,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-6-12.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-6-12.json
@@ -42,7 +42,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-6-12.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-6-12.json
@@ -42,7 +42,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-all.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-all.json
@@ -41,7 +41,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-all.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-all.json
@@ -41,7 +41,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-all.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/jurisdiction-all.json
@@ -41,7 +41,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/overwrite-payment.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/overwrite-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/overwrite-payment.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/overwrite-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "email@email.com",
+    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/overwrite-payment.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/overwrite-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/payment-id-only.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/payment-id-only.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/payment-id-only.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/payment-id-only.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "email@email.com",
+    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/payment-id-only.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/payment-id-only.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/payment.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/payment.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "email@email.com",
+    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/payment.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-adultery.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-adultery.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-adultery.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-adultery.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-adultery.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-adultery.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-desertion.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-desertion.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-desertion.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-desertion.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-desertion.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-desertion.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-separation.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-separation.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-separation.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-separation.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-separation.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-separation.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-unreasonable-behaviour.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-unreasonable-behaviour.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-unreasonable-behaviour.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-unreasonable-behaviour.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-unreasonable-behaviour.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/reason-unreasonable-behaviour.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/same-sex.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/same-sex.json
@@ -37,7 +37,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/same-sex.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/same-sex.json
@@ -37,7 +37,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/same-sex.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/same-sex.json
@@ -37,7 +37,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/submit-complete-case.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/submit-complete-case.json
@@ -50,7 +50,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/submit-complete-case.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/submit-complete-case.json
@@ -50,7 +50,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/submit-complete-case.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/submit-complete-case.json
@@ -50,7 +50,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/update-addresses.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/update-addresses.json
@@ -40,7 +40,7 @@
         "petitionerNameChangedHow": [
           "marriageCertificate"
         ],
-        "petitionerEmail": "email@email.com",
+        "petitionerEmail": "divorce.reform.hmcts@gmail.com",
         "petitionerPhoneNumber": "01234567890",
         "petitionerHomeAddress": {
           "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/update-addresses.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/update-addresses.json
@@ -40,7 +40,7 @@
         "petitionerNameChangedHow": [
           "marriageCertificate"
         ],
-        "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+        "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
         "petitionerPhoneNumber": "01234567890",
         "petitionerHomeAddress": {
           "addressType": "postcode",

--- a/automation-test/src/test/resources/transformservice/divorce-payload-json/update-addresses.json
+++ b/automation-test/src/test/resources/transformservice/divorce-payload-json/update-addresses.json
@@ -40,7 +40,7 @@
         "petitionerNameChangedHow": [
           "marriageCertificate"
         ],
-        "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+        "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
         "petitionerPhoneNumber": "01234567890",
         "petitionerHomeAddress": {
           "addressType": "postcode",

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -8,4 +8,11 @@
         <gav regex="true">^org\.apache\.tomcat:tomcat-annotations-api:.*$</gav>
         <cpe>cpe:/a:apache:tomcat</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: tomcat-embed-core-8.5.29.jar and tomcat-embed-websocket-8.5.29.jar
+   ]]></notes>
+        <gav regex="true">^org\.apache\.tomcat:tomcat-embed:.*$</gav>
+        <cve>CVE-2018-8014</cve>
+    </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -12,7 +12,7 @@
         <notes><![CDATA[
    file name: tomcat-embed-core-8.5.29.jar and tomcat-embed-websocket-8.5.29.jar
    ]]></notes>
-        <gav regex="true">^org\.apache\.tomcat:tomcat-embed:.*$</gav>
+        <filePath regex="true">.*tomcat-embed.*\.jar</filePath>
         <cve>CVE-2018-8014</cve>
     </suppress>
 </suppressions>

--- a/src/test/resources/divorce-payload-json/add-pdf-no-documenttype.json
+++ b/src/test/resources/divorce-payload-json/add-pdf-no-documenttype.json
@@ -13,7 +13,7 @@
       "D8MarriageIsSameSexCouple": "YES",
       "D8MarriageDate": "2001-02-02",
       "D8PetitionerNameDifferentToMarriageCert": "YES",
-      "D8PetitionerEmail": "divorce.reform.hmcts@gmail.com",
+      "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
       "D8PetitionerPhoneNumber": "01234567890",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",

--- a/src/test/resources/divorce-payload-json/add-pdf-no-documenttype.json
+++ b/src/test/resources/divorce-payload-json/add-pdf-no-documenttype.json
@@ -13,7 +13,7 @@
       "D8MarriageIsSameSexCouple": "YES",
       "D8MarriageDate": "2001-02-02",
       "D8PetitionerNameDifferentToMarriageCert": "YES",
-      "D8PetitionerEmail": "email@email.com",
+      "D8PetitionerEmail": "divorce.reform.hmcts@gmail.com",
       "D8PetitionerPhoneNumber": "01234567890",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",

--- a/src/test/resources/divorce-payload-json/add-pdf-no-documenttype.json
+++ b/src/test/resources/divorce-payload-json/add-pdf-no-documenttype.json
@@ -13,7 +13,7 @@
       "D8MarriageIsSameSexCouple": "YES",
       "D8MarriageDate": "2001-02-02",
       "D8PetitionerNameDifferentToMarriageCert": "YES",
-      "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+      "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
       "D8PetitionerPhoneNumber": "01234567890",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",

--- a/src/test/resources/divorce-payload-json/add-pdf-response.json
+++ b/src/test/resources/divorce-payload-json/add-pdf-response.json
@@ -17,7 +17,7 @@
     "D8CountryName":null,
     "D8RejectMarriageDetails":null,
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/test/resources/divorce-payload-json/add-pdf-response.json
+++ b/src/test/resources/divorce-payload-json/add-pdf-response.json
@@ -17,7 +17,7 @@
     "D8CountryName":null,
     "D8RejectMarriageDetails":null,
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"email@email.com",
+    "D8PetitionerEmail":"divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/test/resources/divorce-payload-json/add-pdf-response.json
+++ b/src/test/resources/divorce-payload-json/add-pdf-response.json
@@ -17,7 +17,7 @@
     "D8CountryName":null,
     "D8RejectMarriageDetails":null,
     "D8PetitionerNameDifferentToMarriageCert":"YES",
-    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber":"01234567890",
     "D8PetitionerFirstName":"John",
     "D8PetitionerLastName":"Smith",

--- a/src/test/resources/divorce-payload-json/add-pdf.json
+++ b/src/test/resources/divorce-payload-json/add-pdf.json
@@ -13,7 +13,7 @@
       "D8MarriageIsSameSexCouple": "YES",
       "D8MarriageDate": "2001-02-02",
       "D8PetitionerNameDifferentToMarriageCert": "YES",
-      "D8PetitionerEmail": "divorce.reform.hmcts@gmail.com",
+      "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
       "D8PetitionerPhoneNumber": "01234567890",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",

--- a/src/test/resources/divorce-payload-json/add-pdf.json
+++ b/src/test/resources/divorce-payload-json/add-pdf.json
@@ -13,7 +13,7 @@
       "D8MarriageIsSameSexCouple": "YES",
       "D8MarriageDate": "2001-02-02",
       "D8PetitionerNameDifferentToMarriageCert": "YES",
-      "D8PetitionerEmail": "email@email.com",
+      "D8PetitionerEmail": "divorce.reform.hmcts@gmail.com",
       "D8PetitionerPhoneNumber": "01234567890",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",

--- a/src/test/resources/divorce-payload-json/add-pdf.json
+++ b/src/test/resources/divorce-payload-json/add-pdf.json
@@ -13,7 +13,7 @@
       "D8MarriageIsSameSexCouple": "YES",
       "D8MarriageDate": "2001-02-02",
       "D8PetitionerNameDifferentToMarriageCert": "YES",
-      "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+      "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
       "D8PetitionerPhoneNumber": "01234567890",
       "D8PetitionerFirstName": "John",
       "D8PetitionerLastName": "Smith",

--- a/src/test/resources/divorce-payload-json/additional-payment.json
+++ b/src/test/resources/divorce-payload-json/additional-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/additional-payment.json
+++ b/src/test/resources/divorce-payload-json/additional-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "email@email.com",
+    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/additional-payment.json
+++ b/src/test/resources/divorce-payload-json/additional-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/addresses.json
+++ b/src/test/resources/divorce-payload-json/addresses.json
@@ -39,7 +39,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/addresses.json
+++ b/src/test/resources/divorce-payload-json/addresses.json
@@ -39,7 +39,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/addresses.json
+++ b/src/test/resources/divorce-payload-json/addresses.json
@@ -39,7 +39,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/d8-document.json
+++ b/src/test/resources/divorce-payload-json/d8-document.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/d8-document.json
+++ b/src/test/resources/divorce-payload-json/d8-document.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "email@email.com",
+    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/d8-document.json
+++ b/src/test/resources/divorce-payload-json/d8-document.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/how-name-changed.json
+++ b/src/test/resources/divorce-payload-json/how-name-changed.json
@@ -44,7 +44,7 @@
     "deedPoll",
     "other"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/how-name-changed.json
+++ b/src/test/resources/divorce-payload-json/how-name-changed.json
@@ -44,7 +44,7 @@
     "deedPoll",
     "other"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/how-name-changed.json
+++ b/src/test/resources/divorce-payload-json/how-name-changed.json
@@ -44,7 +44,7 @@
     "deedPoll",
     "other"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/jurisdiction-6-12.json
+++ b/src/test/resources/divorce-payload-json/jurisdiction-6-12.json
@@ -42,7 +42,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/jurisdiction-6-12.json
+++ b/src/test/resources/divorce-payload-json/jurisdiction-6-12.json
@@ -42,7 +42,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/jurisdiction-6-12.json
+++ b/src/test/resources/divorce-payload-json/jurisdiction-6-12.json
@@ -42,7 +42,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/jurisdiction-all.json
+++ b/src/test/resources/divorce-payload-json/jurisdiction-all.json
@@ -41,7 +41,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/jurisdiction-all.json
+++ b/src/test/resources/divorce-payload-json/jurisdiction-all.json
@@ -41,7 +41,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/jurisdiction-all.json
+++ b/src/test/resources/divorce-payload-json/jurisdiction-all.json
@@ -41,7 +41,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/overwrite-payment.json
+++ b/src/test/resources/divorce-payload-json/overwrite-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/overwrite-payment.json
+++ b/src/test/resources/divorce-payload-json/overwrite-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "email@email.com",
+    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/overwrite-payment.json
+++ b/src/test/resources/divorce-payload-json/overwrite-payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/payment-id-only.json
+++ b/src/test/resources/divorce-payload-json/payment-id-only.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/payment-id-only.json
+++ b/src/test/resources/divorce-payload-json/payment-id-only.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "email@email.com",
+    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/payment-id-only.json
+++ b/src/test/resources/divorce-payload-json/payment-id-only.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/payment.json
+++ b/src/test/resources/divorce-payload-json/payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/payment.json
+++ b/src/test/resources/divorce-payload-json/payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "email@email.com",
+    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/payment.json
+++ b/src/test/resources/divorce-payload-json/payment.json
@@ -51,7 +51,7 @@
     "petitionerNameChangedHow": [
         "marriageCertificate"
     ],
-    "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+    "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
     "petitionerPhoneNumber": "01234567890",
     "petitionerHomeAddress": {
         "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-adultery.json
+++ b/src/test/resources/divorce-payload-json/reason-adultery.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-adultery.json
+++ b/src/test/resources/divorce-payload-json/reason-adultery.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-adultery.json
+++ b/src/test/resources/divorce-payload-json/reason-adultery.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-desertion.json
+++ b/src/test/resources/divorce-payload-json/reason-desertion.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-desertion.json
+++ b/src/test/resources/divorce-payload-json/reason-desertion.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-desertion.json
+++ b/src/test/resources/divorce-payload-json/reason-desertion.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-separation.json
+++ b/src/test/resources/divorce-payload-json/reason-separation.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-separation.json
+++ b/src/test/resources/divorce-payload-json/reason-separation.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-separation.json
+++ b/src/test/resources/divorce-payload-json/reason-separation.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-unreasonable-behaviour.json
+++ b/src/test/resources/divorce-payload-json/reason-unreasonable-behaviour.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-unreasonable-behaviour.json
+++ b/src/test/resources/divorce-payload-json/reason-unreasonable-behaviour.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/reason-unreasonable-behaviour.json
+++ b/src/test/resources/divorce-payload-json/reason-unreasonable-behaviour.json
@@ -51,7 +51,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/same-sex.json
+++ b/src/test/resources/divorce-payload-json/same-sex.json
@@ -37,7 +37,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "email@email.com",
+  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/same-sex.json
+++ b/src/test/resources/divorce-payload-json/same-sex.json
@@ -37,7 +37,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "divorce.reform.hmcts@gmail.com",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/divorce-payload-json/same-sex.json
+++ b/src/test/resources/divorce-payload-json/same-sex.json
@@ -37,7 +37,7 @@
   "petitionerNameChangedHow": [
     "marriageCertificate"
   ],
-  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk ",
+  "petitionerEmail": "simulate-delivered@notifications.service.gov.uk",
   "petitionerPhoneNumber": "01234567890",
   "petitionerHomeAddress": {
     "addressType": "postcode",

--- a/src/test/resources/fixtures/ccd/address-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/address-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/address-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/address-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/address-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/address-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/d8-document-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/d8-document-case-submission-request-body.json
@@ -14,7 +14,7 @@
         "D8MarriageDate" : "2001-02-02",
         "D8MarriedInUk" : "YES",
         "D8PetitionerNameDifferentToMarriageCert" : "YES",
-        "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+        "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
         "D8PetitionerPhoneNumber" : "01234567890",
         "D8PetitionerFirstName" : "John",
         "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/d8-document-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/d8-document-case-submission-request-body.json
@@ -14,7 +14,7 @@
         "D8MarriageDate" : "2001-02-02",
         "D8MarriedInUk" : "YES",
         "D8PetitionerNameDifferentToMarriageCert" : "YES",
-        "D8PetitionerEmail" : "email@email.com",
+        "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
         "D8PetitionerPhoneNumber" : "01234567890",
         "D8PetitionerFirstName" : "John",
         "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/d8-document-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/d8-document-case-submission-request-body.json
@@ -14,7 +14,7 @@
         "D8MarriageDate" : "2001-02-02",
         "D8MarriedInUk" : "YES",
         "D8PetitionerNameDifferentToMarriageCert" : "YES",
-        "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+        "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
         "D8PetitionerPhoneNumber" : "01234567890",
         "D8PetitionerFirstName" : "John",
         "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/how-name-changed-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/how-name-changed-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/how-name-changed-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/how-name-changed-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/how-name-changed-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/how-name-changed-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/jurisdiction-6-12-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/jurisdiction-6-12-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/jurisdiction-6-12-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/jurisdiction-6-12-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/jurisdiction-6-12-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/jurisdiction-6-12-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/jurisdiction-all-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/jurisdiction-all-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "YES",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/jurisdiction-all-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/jurisdiction-all-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "YES",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/jurisdiction-all-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/jurisdiction-all-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "YES",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/payment-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/payment-case-submission-request-body.json
@@ -14,7 +14,7 @@
         "D8MarriageDate" : "2001-02-02",
         "D8MarriedInUk" : "YES",
         "D8PetitionerNameDifferentToMarriageCert" : "YES",
-        "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+        "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
         "D8PetitionerPhoneNumber" : "01234567890",
         "D8PetitionerFirstName" : "John",
         "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/payment-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/payment-case-submission-request-body.json
@@ -14,7 +14,7 @@
         "D8MarriageDate" : "2001-02-02",
         "D8MarriedInUk" : "YES",
         "D8PetitionerNameDifferentToMarriageCert" : "YES",
-        "D8PetitionerEmail" : "email@email.com",
+        "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
         "D8PetitionerPhoneNumber" : "01234567890",
         "D8PetitionerFirstName" : "John",
         "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/payment-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/payment-case-submission-request-body.json
@@ -14,7 +14,7 @@
         "D8MarriageDate" : "2001-02-02",
         "D8MarriedInUk" : "YES",
         "D8PetitionerNameDifferentToMarriageCert" : "YES",
-        "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+        "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
         "D8PetitionerPhoneNumber" : "01234567890",
         "D8PetitionerFirstName" : "John",
         "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-adultery-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-adultery-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-adultery-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-adultery-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-adultery-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-adultery-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-desertion-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-desertion-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-desertion-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-desertion-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-desertion-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-desertion-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-separation-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-separation-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-separation-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-separation-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-separation-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-separation-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-unreasonable-behaviour-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-unreasonable-behaviour-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-unreasonable-behaviour-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-unreasonable-behaviour-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/reason-unreasonable-behaviour-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/reason-unreasonable-behaviour-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "NO",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/same-sex-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/same-sex-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "YES",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/same-sex-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/same-sex-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "YES",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccd/same-sex-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/same-sex-case-submission-request-body.json
@@ -13,7 +13,7 @@
     "D8MarriageIsSameSexCouple" : "YES",
     "D8MarriageDate" : "2001-02-02",
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/additionalpayment.json
+++ b/src/test/resources/fixtures/ccdmapping/additionalpayment.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/additionalpayment.json
+++ b/src/test/resources/fixtures/ccdmapping/additionalpayment.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/additionalpayment.json
+++ b/src/test/resources/fixtures/ccdmapping/additionalpayment.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/addresscase.json
+++ b/src/test/resources/fixtures/ccdmapping/addresscase.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/addresscase.json
+++ b/src/test/resources/fixtures/ccdmapping/addresscase.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/addresscase.json
+++ b/src/test/resources/fixtures/ccdmapping/addresscase.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/d8document.json
+++ b/src/test/resources/fixtures/ccdmapping/d8document.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/d8document.json
+++ b/src/test/resources/fixtures/ccdmapping/d8document.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/d8document.json
+++ b/src/test/resources/fixtures/ccdmapping/d8document.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/hownamechanged.json
+++ b/src/test/resources/fixtures/ccdmapping/hownamechanged.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/hownamechanged.json
+++ b/src/test/resources/fixtures/ccdmapping/hownamechanged.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/hownamechanged.json
+++ b/src/test/resources/fixtures/ccdmapping/hownamechanged.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/jurisdiction612.json
+++ b/src/test/resources/fixtures/ccdmapping/jurisdiction612.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/jurisdiction612.json
+++ b/src/test/resources/fixtures/ccdmapping/jurisdiction612.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/jurisdiction612.json
+++ b/src/test/resources/fixtures/ccdmapping/jurisdiction612.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/jurisdictionall.json
+++ b/src/test/resources/fixtures/ccdmapping/jurisdictionall.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/jurisdictionall.json
+++ b/src/test/resources/fixtures/ccdmapping/jurisdictionall.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/jurisdictionall.json
+++ b/src/test/resources/fixtures/ccdmapping/jurisdictionall.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/overwritepayment.json
+++ b/src/test/resources/fixtures/ccdmapping/overwritepayment.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/overwritepayment.json
+++ b/src/test/resources/fixtures/ccdmapping/overwritepayment.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/overwritepayment.json
+++ b/src/test/resources/fixtures/ccdmapping/overwritepayment.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/paymentcase.json
+++ b/src/test/resources/fixtures/ccdmapping/paymentcase.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/paymentcase.json
+++ b/src/test/resources/fixtures/ccdmapping/paymentcase.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/paymentcase.json
+++ b/src/test/resources/fixtures/ccdmapping/paymentcase.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/paymentidonly.json
+++ b/src/test/resources/fixtures/ccdmapping/paymentidonly.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/paymentidonly.json
+++ b/src/test/resources/fixtures/ccdmapping/paymentidonly.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/paymentidonly.json
+++ b/src/test/resources/fixtures/ccdmapping/paymentidonly.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasonadultery.json
+++ b/src/test/resources/fixtures/ccdmapping/reasonadultery.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasonadultery.json
+++ b/src/test/resources/fixtures/ccdmapping/reasonadultery.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasonadultery.json
+++ b/src/test/resources/fixtures/ccdmapping/reasonadultery.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasondesertion.json
+++ b/src/test/resources/fixtures/ccdmapping/reasondesertion.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasondesertion.json
+++ b/src/test/resources/fixtures/ccdmapping/reasondesertion.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasondesertion.json
+++ b/src/test/resources/fixtures/ccdmapping/reasondesertion.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasonseparation.json
+++ b/src/test/resources/fixtures/ccdmapping/reasonseparation.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasonseparation.json
+++ b/src/test/resources/fixtures/ccdmapping/reasonseparation.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasonseparation.json
+++ b/src/test/resources/fixtures/ccdmapping/reasonseparation.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasonunreasonablebehaviour.json
+++ b/src/test/resources/fixtures/ccdmapping/reasonunreasonablebehaviour.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasonunreasonablebehaviour.json
+++ b/src/test/resources/fixtures/ccdmapping/reasonunreasonablebehaviour.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/reasonunreasonablebehaviour.json
+++ b/src/test/resources/fixtures/ccdmapping/reasonunreasonablebehaviour.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/samesex.json
+++ b/src/test/resources/fixtures/ccdmapping/samesex.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/samesex.json
+++ b/src/test/resources/fixtures/ccdmapping/samesex.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/ccdmapping/samesex.json
+++ b/src/test/resources/fixtures/ccdmapping/samesex.json
@@ -16,7 +16,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/divorce/reason-adultery-case-submission-request-body.json
+++ b/src/test/resources/fixtures/divorce/reason-adultery-case-submission-request-body.json
@@ -22,7 +22,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/divorce/reason-adultery-case-submission-request-body.json
+++ b/src/test/resources/fixtures/divorce/reason-adultery-case-submission-request-body.json
@@ -22,7 +22,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk ",
+    "D8PetitionerEmail" : "simulate-delivered@notifications.service.gov.uk",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/divorce/reason-adultery-case-submission-request-body.json
+++ b/src/test/resources/fixtures/divorce/reason-adultery-case-submission-request-body.json
@@ -22,7 +22,7 @@
     "D8CountryName" : null,
     "D8RejectMarriageDetails" : null,
     "D8PetitionerNameDifferentToMarriageCert" : "YES",
-    "D8PetitionerEmail" : "email@email.com",
+    "D8PetitionerEmail" : "divorce.reform.hmcts@gmail.com",
     "D8PetitionerPhoneNumber" : "01234567890",
     "D8PetitionerFirstName" : "John",
     "D8PetitionerLastName" : "Smith",

--- a/src/test/resources/fixtures/pdf-generator/generate-pdf-request.json
+++ b/src/test/resources/fixtures/pdf-generator/generate-pdf-request.json
@@ -20,7 +20,7 @@
                 "D8CountryName":null,
                 "D8RejectMarriageDetails":null,
                 "D8PetitionerNameDifferentToMarriageCert":"YES",
-                "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk ",
+                "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk",
                 "D8PetitionerPhoneNumber":"01234567890",
                 "D8PetitionerFirstName":"John",
                 "D8PetitionerLastName":"Smith",

--- a/src/test/resources/fixtures/pdf-generator/generate-pdf-request.json
+++ b/src/test/resources/fixtures/pdf-generator/generate-pdf-request.json
@@ -20,7 +20,7 @@
                 "D8CountryName":null,
                 "D8RejectMarriageDetails":null,
                 "D8PetitionerNameDifferentToMarriageCert":"YES",
-                "D8PetitionerEmail":"email@email.com",
+                "D8PetitionerEmail":"divorce.reform.hmcts@gmail.com",
                 "D8PetitionerPhoneNumber":"01234567890",
                 "D8PetitionerFirstName":"John",
                 "D8PetitionerLastName":"Smith",

--- a/src/test/resources/fixtures/pdf-generator/generate-pdf-request.json
+++ b/src/test/resources/fixtures/pdf-generator/generate-pdf-request.json
@@ -20,7 +20,7 @@
                 "D8CountryName":null,
                 "D8RejectMarriageDetails":null,
                 "D8PetitionerNameDifferentToMarriageCert":"YES",
-                "D8PetitionerEmail":"divorce.reform.hmcts@gmail.com",
+                "D8PetitionerEmail":"simulate-delivered@notifications.service.gov.uk ",
                 "D8PetitionerPhoneNumber":"01234567890",
                 "D8PetitionerFirstName":"John",
                 "D8PetitionerLastName":"Smith",


### PR DESCRIPTION
Don't use email@email.com for tests as this could spam GOV.UK notify with rejected notifications.