### PR TITLE
Map Solicitor name and company to CCD

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/DivorceCaseToCCDMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/DivorceCaseToCCDMapper.java
@@ -94,6 +94,8 @@ public abstract class DivorceCaseToCCDMapper {
         expression =
             "java(java.time.LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern(\"yyyy-MM-dd\")))")
     @Mapping(source = "d8Documents", target = "d8Documents")
+    @Mapping(source = "respondentSolicitorName", target = "d8RespondentSolicitorName")
+    @Mapping(source = "respondentSolicitorCompany", target = "d8RespondentSolicitorCompany")
     public abstract CoreCaseData divorceCaseDataToCourtCaseData(DivorceSession divorceSession);
 
     private String translateToStringYesNo(final String value) {

--- a/src/test/resources/fixtures/ccd/address-case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/address-case-submission-request-body.json
@@ -32,6 +32,8 @@
     "D8RespondentFirstName" : "Jane",
     "D8RespondentLastName" : "Jamed",
     "D8DerivedRespondentCurrentName" : "Jane Jamed",
+    "D8RespondentSolicitorName": "Justin",
+    "D8RespondentSolicitorCompany": "Case",
     "D8DerivedRespondentSolicitorDetails" : "Justin\nCase\n90 Landor Road\nLondon\nSW9 9PE",
     "D8RespondentHomeAddress" : {
       "PostCode" : "SS SSS"

--- a/src/test/resources/fixtures/ccdmapping/addresscase.json
+++ b/src/test/resources/fixtures/ccdmapping/addresscase.json
@@ -50,8 +50,8 @@
       "PostCode" : "SW9 9PE"
     },
     "D8DerivedRespondentCorrespondenceAddr" : "82 Landor Road\nLondon\nSW9 9PE",
-    "D8RespondentSolicitorName" : null,
-    "D8RespondentSolicitorCompany" : null,
+    "D8RespondentSolicitorName" : "Justin",
+    "D8RespondentSolicitorCompany" : "Case",
     "D8RespondentCorrespondenceSendToSol" : null,
     "D8RespondentSolicitorAddress" : null,
     "D8RespondentCorrespondenceUseHomeAddress" : "Solicitor",


### PR DESCRIPTION
# Description

DerivedSolicitorDetails made up of Solicitor Name, Solicitor Company and Solicitor Address is being mapped and saved to CCD.
With the removal of Derived fields upcoming, the three parts needs to be mapped to CCD as well. Currently Solicitor Address is already being mapped, but Solicitor Company and Solicitor Name was not. This PR maps these two from session as well.

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Modified existing unit test cases to work for the new mapping additions.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
