### PR TITLE
Set petitionerEmail based on IDAM data retrieval

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/service/SubmissionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/service/SubmissionService.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.reform.divorce.transformservice.domain.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.transformservice.domain.ccd.SubmitEvent;
 import uk.gov.hmcts.reform.divorce.transformservice.domain.model.divorceapplicationdata.DivorceSession;
 
+import java.util.Objects;
+
 @Component
 @Slf4j
 public class SubmissionService {
@@ -30,6 +32,10 @@ public class SubmissionService {
 
     public long submit(final DivorceSession divorceSessionData, final String jwt) {
         UserDetails userDetails = userService.getUserDetails(jwt);
+        if (Objects.nonNull(userDetails)) {
+            divorceSessionData.setPetitionerEmail(userDetails.getEmail());
+        }
+
         CreateEvent createEvent = ccdClient.createCase(userDetails, jwt, divorceSessionData);
 
         SubmitEvent submitEvent = ccdClient.submitCase(userDetails, jwt,

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/service/SubmissionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/service/SubmissionServiceTest.java
@@ -44,14 +44,16 @@ public class SubmissionServiceTest {
 
     @Test
     public void submitReturnsCaseId() throws Exception {
-        final DivorceSession divorceSession = new DivorceSession();
+        DivorceSession divorceSession = new DivorceSession();
         final CaseDataContent caseDataContent = mock(CaseDataContent.class);
         String jwt = "_jwt";
         String token = "_token";
         final String eventSummary = "Create case";
         int caseId = 2893;
         String userId = "60";
-        UserDetails userDetails = UserDetails.builder().id(userId).build();
+        String userEmail = "simulate-delivered@notifications.service.gov.uk";
+        UserDetails userDetails = UserDetails.builder().id(userId).email(userEmail).build();
+        divorceSession.setPetitionerEmail(userEmail);
         CreateEvent createEvent = new CreateEvent();
         createEvent.setToken(token);
         SubmitEvent submitEvent = new SubmitEvent();

--- a/src/test/resources/fixtures/ccd/case-submission-request-body.json
+++ b/src/test/resources/fixtures/ccd/case-submission-request-body.json
@@ -7,6 +7,7 @@
   "data" : {
     "D8PetitionerFirstName" : "Danny",
     "D8DerivedPetitionerCurrentFullName" : "Danny ",
+    "D8PetitionerEmail": "simulate-delivered@notifications.service.gov.uk",
     "D8Cohort" : "onlineSubmissionPrivateBeta"
   },
   "security_classification" : null,

--- a/src/test/resources/fixtures/idam/user-details-200-response.json
+++ b/src/test/resources/fixtures/idam/user-details-200-response.json
@@ -1,6 +1,6 @@
 {
   "id": "60",
-  "email": "john.doe@notifications.service.gov.uk",
+  "email": "simulate-delivered@notifications.service.gov.uk",
   "forename": "John",
   "surname": "Doe",
   "roles": []


### PR DESCRIPTION
Note that the implementation of this may not be the best, but is the simplest.
We have removed petitionerEmail from frontend session but not the CPS model. This means petitionerEmail will always be set to null in CPS.
This change now sets petitionerEmail before submission (we should assume updates and callbacks they should already have the email for) using details retrieved from IDAM (/details endpoint with the JWT passed from frontend).
This means the mapper will map the petitionerEmail to D8PetitionerEmail before sending it to CCD.