### PR TITLE
Temporary fix to set StatementOfTruth to YES on ISSUE

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/controller/CcdCallBackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/controller/CcdCallBackController.java
@@ -71,6 +71,12 @@ public class CcdCallBackController {
         @RequestHeader(value = "Authorization", required = false) String authorizationToken,
         @RequestBody @ApiParam("CaseData") CreateEvent caseDetailsRequest) {
 
+        // Temporary fix. The user should not be able to submit a case without confirming the statment of truth
+        // This fixes a bug where the statement of truth is not set properly when saved to CCD
+        if (caseDetailsRequest.getCaseDetails().getCaseData() != null) {
+            caseDetailsRequest.getCaseDetails().getCaseData().setD8StatementOfTruth("YES");
+        }
+
         ValidationResponse validationResponse = validationService.validateCoreCaseData(
             caseDetailsRequest.getCaseDetails().getCaseData()
         );

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/controller/CcdCallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/controller/CcdCallbackControllerTest.java
@@ -90,6 +90,7 @@ public class CcdCallbackControllerTest {
         final Long caseId = 1235678L;
 
         CoreCaseData coreCaseData = new CoreCaseData();
+        coreCaseData.setD8StatementOfTruth("YES");
 
         CreateEvent submittedCase = new CreateEvent();
         submittedCase.setEventId("uploadDocument");

--- a/src/test/resources/divorce-payload-json/add-pdf-no-documenttype.json
+++ b/src/test/resources/divorce-payload-json/add-pdf-no-documenttype.json
@@ -132,7 +132,8 @@
       "D8ReasonForDivorceClaiming5YearSeparatio": "NO",
       "D8Cohort": "onlineSubmissionPrivateBeta",
       "D8InferredPetitionerGender": "female",
-      "D8InferredRespondentGender": "female"
+      "D8InferredRespondentGender": "female",
+      "D8StatementOfTruth": "YES"
     }
   }
 }

--- a/src/test/resources/divorce-payload-json/add-pdf-response-with-errors.json
+++ b/src/test/resources/divorce-payload-json/add-pdf-response-with-errors.json
@@ -173,7 +173,7 @@
         }
       ],
       "D8RejectDocumentsUploaded":null,
-      "D8StatementOfTruth":null,
+      "D8StatementOfTruth":"YES",
       "D8SolicitorReference":null,
       "D8DivorceUnit":"eastMidlands",
       "D8ReasonForDivorceShowAdultery":"YES",

--- a/src/test/resources/divorce-payload-json/add-pdf-response-with-warnings.json
+++ b/src/test/resources/divorce-payload-json/add-pdf-response-with-warnings.json
@@ -173,7 +173,7 @@
         }
       ],
       "D8RejectDocumentsUploaded":null,
-      "D8StatementOfTruth":null,
+      "D8StatementOfTruth":"YES",
       "D8SolicitorReference":null,
       "D8DivorceUnit":"eastMidlands",
       "D8ReasonForDivorceShowAdultery":"YES",

--- a/src/test/resources/divorce-payload-json/add-pdf-response.json
+++ b/src/test/resources/divorce-payload-json/add-pdf-response.json
@@ -173,7 +173,7 @@
       }
     ],
     "D8RejectDocumentsUploaded":null,
-    "D8StatementOfTruth":null,
+    "D8StatementOfTruth":"YES",
     "D8SolicitorReference":null,
     "D8DivorceUnit":"eastMidlands",
     "D8ReasonForDivorceShowAdultery":"YES",

--- a/src/test/resources/divorce-payload-json/add-pdf.json
+++ b/src/test/resources/divorce-payload-json/add-pdf.json
@@ -133,7 +133,8 @@
       "D8ReasonForDivorceClaiming5YearSeparatio": "NO",
       "D8Cohort": "onlineSubmissionPrivateBeta",
       "D8InferredPetitionerGender": "female",
-      "D8InferredRespondentGender": "female"
+      "D8InferredRespondentGender": "female",
+      "D8StatementOfTruth": "YES"
     }
   }
 }

--- a/src/test/resources/fixtures/pdf-generator/generate-pdf-request.json
+++ b/src/test/resources/fixtures/pdf-generator/generate-pdf-request.json
@@ -172,7 +172,7 @@
                     }
                 ],
                 "D8RejectDocumentsUploaded":null,
-                "D8StatementOfTruth":null,
+                "D8StatementOfTruth":"YES",
                 "D8SolicitorReference":null,
                 "D8DivorceUnit":"eastMidlands",
                 "D8ReasonForDivorceShowAdultery":"YES",

--- a/src/test/resources/fixtures/validation-service/validate-request-no-documenttype.json
+++ b/src/test/resources/fixtures/validation-service/validate-request-no-documenttype.json
@@ -169,7 +169,7 @@
             }
         ],
         "D8RejectDocumentsUploaded":null,
-        "D8StatementOfTruth":null,
+        "D8StatementOfTruth":"YES",
         "D8SolicitorReference":null,
         "D8DivorceUnit":"eastMidlands",
         "D8ReasonForDivorceShowAdultery":"YES",

--- a/src/test/resources/fixtures/validation-service/validate-request.json
+++ b/src/test/resources/fixtures/validation-service/validate-request.json
@@ -169,7 +169,7 @@
             }
         ],
         "D8RejectDocumentsUploaded":null,
-        "D8StatementOfTruth":null,
+        "D8StatementOfTruth":"YES",
         "D8SolicitorReference":null,
         "D8DivorceUnit":"eastMidlands",
         "D8ReasonForDivorceShowAdultery":"YES",


### PR DESCRIPTION
As users should be unable to submit to CCD without checking the statementOfTruth box, this will set D8StatementOfTruth to "YES" on all Issue callbacks.