### PR TITLE
[PREVIEW] DIV-2752 Updating a case should not overwrite its createdDate

### DIFF
--- a/automation-test/src/test/java/uk/gov/hmcts/reform/divorce/caseprogression/transformapi/CoreCaseDataUpdateIntegrationTest.java
+++ b/automation-test/src/test/java/uk/gov/hmcts/reform/divorce/caseprogression/transformapi/CoreCaseDataUpdateIntegrationTest.java
@@ -122,17 +122,6 @@ public class CoreCaseDataUpdateIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    public void shouldReturnErrorForInvalidSessionData() throws Exception {
-
-        String caseId = getCaseIdFromSubmittingANewCase();
-
-        Response ccdResponse = postToRestService(loadJson("invalid-update-session.json"),
-            String.join(URL_SEPARATOR, transformationApiUpdateUrl, caseId));
-
-        assertResponseErrorsAreAsExpected(ccdResponse, CASE_VALIDATION_EXCEPTION, "\"details\":{\"field_errors\":[{\"id\":\"D8DivorceWho\",\"message\":\"notAValidValue is not a valid value\"}]}");
-    }
-
-    @Test
     public void shouldReturnErrorForInvalidUserJwtToken() throws Exception {
 
         String caseId = getCaseIdFromSubmittingANewCase();

--- a/automation-test/src/test/resources/divorce-payload-json/invalid-update-session.json
+++ b/automation-test/src/test/resources/divorce-payload-json/invalid-update-session.json
@@ -1,6 +1,0 @@
-{
-    "eventData" : {
-        "divorceWho" : "notAValidValue"
-    },
-    "eventId" : "paymentMade"
-}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/DivorceCaseToCCDPaymentUpdateMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/DivorceCaseToCCDPaymentUpdateMapper.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.divorce.transformservice.mapping;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.ReportingPolicy;
+import org.springframework.beans.factory.annotation.Value;
+import uk.gov.hmcts.reform.divorce.transformservice.domain.model.ccd.CoreCaseData;
+import uk.gov.hmcts.reform.divorce.transformservice.domain.model.divorceapplicationdata.DivorceSession;
+import uk.gov.hmcts.reform.divorce.transformservice.strategy.payments.PaymentContext;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+@Mapper(componentModel = "spring", uses = DocumentCollectionMapper.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public abstract class DivorceCaseToCCDPaymentUpdateMapper {
+
+    private final PaymentContext paymentContext = new PaymentContext();
+
+    @Value("${cohort}")
+    private String cohort;
+
+    public abstract CoreCaseData divorceCaseDataToCourtCaseData(DivorceSession divorceSession);
+
+    @AfterMapping
+    protected void mapPayments(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
+        if (Objects.nonNull(divorceSession.getPayment())) {
+
+            if (Objects.nonNull(divorceSession.getPayment().getPaymentDate())) {
+                divorceSession.getPayment().setPaymentDate(LocalDate.parse(
+                    divorceSession.getPayment().getPaymentDate(), DateTimeFormatter.ofPattern("ddMMyyyy"))
+                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+            }
+
+            result.setPayments(paymentContext.getListOfPayments(divorceSession));
+        }
+    }
+
+    @AfterMapping
+    protected void mapCohort(DivorceSession divorceSession, @MappingTarget CoreCaseData result) {
+        result.setD8Cohort(cohort);
+    }
+
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/DivorceCaseToCCDSubmissionMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/DivorceCaseToCCDSubmissionMapper.java
@@ -23,12 +23,11 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static java.lang.String.join;
-import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Mapper(componentModel = "spring", uses = {DocumentCollectionMapper.class},
     unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public abstract class DivorceCaseToCCDMapper {
+public abstract class DivorceCaseToCCDSubmissionMapper {
 
     private static final String BLANK_SPACE = " ";
     private static final String LINE_SEPARATOR = "\n";
@@ -96,12 +95,12 @@ public abstract class DivorceCaseToCCDMapper {
     @Mapping(source = "connectionSummary", target = "d8ConnectionSummary")
     @Mapping(source = "courts", target = "d8DivorceUnit")
     @Mapping(source = "marriageCertificateFiles", target = "d8DocumentsUploaded")
-    @Mapping(target = "createdDate",
-        expression =
-            "java(java.time.LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern(\"yyyy-MM-dd\")))")
     @Mapping(source = "d8Documents", target = "d8Documents")
     @Mapping(source = "respondentSolicitorName", target = "d8RespondentSolicitorName")
     @Mapping(source = "respondentSolicitorCompany", target = "d8RespondentSolicitorCompany")
+    @Mapping(target = "createdDate",
+        expression =
+            "java(java.time.LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern(\"yyyy-MM-dd\")))")
     public abstract CoreCaseData divorceCaseDataToCourtCaseData(DivorceSession divorceSession);
 
     private String translateToStringYesNo(final String value) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/service/DivorceToCcdTransformationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/service/DivorceToCcdTransformationService.java
@@ -9,7 +9,8 @@ import uk.gov.hmcts.reform.divorce.transformservice.domain.model.ccd.CaseDataCon
 import uk.gov.hmcts.reform.divorce.transformservice.domain.model.ccd.CoreCaseData;
 import uk.gov.hmcts.reform.divorce.transformservice.domain.model.ccd.Event;
 import uk.gov.hmcts.reform.divorce.transformservice.domain.model.divorceapplicationdata.DivorceSession;
-import uk.gov.hmcts.reform.divorce.transformservice.mapping.DivorceCaseToCCDMapper;
+import uk.gov.hmcts.reform.divorce.transformservice.mapping.DivorceCaseToCCDPaymentUpdateMapper;
+import uk.gov.hmcts.reform.divorce.transformservice.mapping.DivorceCaseToCCDSubmissionMapper;
 
 import java.util.Map;
 import java.util.Objects;
@@ -19,31 +20,49 @@ public class DivorceToCcdTransformationService implements TransformationService 
 
     private final ObjectMapper objectMapper;
 
-    private final DivorceCaseToCCDMapper divorceCaseToCCDMapper;
+    private final DivorceCaseToCCDSubmissionMapper divorceCaseToCCDSubmissionMapper;
+    private final DivorceCaseToCCDPaymentUpdateMapper divorceCaseToCCDPaymentUpdateMapper;
 
     @Autowired
-    public DivorceToCcdTransformationService(DivorceCaseToCCDMapper divorceCaseToCCDMapper) {
-        this.divorceCaseToCCDMapper = divorceCaseToCCDMapper;
-
+    public DivorceToCcdTransformationService(DivorceCaseToCCDSubmissionMapper divorceCaseToCCDSubmissionMapper,
+                                             DivorceCaseToCCDPaymentUpdateMapper divorceCaseToCCDPaymentUpdateMapper) {
+        this.divorceCaseToCCDSubmissionMapper = divorceCaseToCCDSubmissionMapper;
+        this.divorceCaseToCCDPaymentUpdateMapper = divorceCaseToCCDPaymentUpdateMapper;
         this.objectMapper = new ObjectMapper();
         this.objectMapper.setSerializationInclusion(Include.NON_NULL);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public CaseDataContent transform(DivorceSession divorceSession, CreateEvent createEvent, String eventSummary) {
+    public CaseDataContent transformSubmission(DivorceSession divorceSession,
+                                               CreateEvent createEvent,
+                                               String eventSummary) {
+
+        CoreCaseData coreCaseData = divorceCaseToCCDSubmissionMapper.divorceCaseDataToCourtCaseData(divorceSession);
+        return buildCaseDataContent(createEvent, eventSummary, coreCaseData);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public CaseDataContent transformUpdate(DivorceSession divorceSession,
+                                           CreateEvent createEvent,
+                                           String eventSummary) {
 
         if (Objects.nonNull(createEvent.getCaseDetails().getCaseData())) {
             divorceSession.setExistingPayments(createEvent.getCaseDetails().getCaseData().getPayments());
         }
 
-        CoreCaseData coreCaseData = divorceCaseToCCDMapper.divorceCaseDataToCourtCaseData(divorceSession);
+        CoreCaseData coreCaseData = divorceCaseToCCDPaymentUpdateMapper.divorceCaseDataToCourtCaseData(divorceSession);
+        return buildCaseDataContent(createEvent, eventSummary, coreCaseData);
+    }
 
+    private CaseDataContent buildCaseDataContent(CreateEvent createEvent,
+                                                 String eventSummary,
+                                                 CoreCaseData coreCaseData) {
         return CaseDataContent.builder()
             .data(objectMapper.convertValue(coreCaseData, Map.class))
             .token(createEvent.getToken())
             .event(Event.builder().eventId(createEvent.getEventId()).summary(eventSummary).build())
             .build();
-
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/service/SubmissionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/service/SubmissionService.java
@@ -33,7 +33,7 @@ public class SubmissionService {
         CreateEvent createEvent = ccdClient.createCase(userDetails, jwt, divorceSessionData);
 
         SubmitEvent submitEvent = ccdClient.submitCase(userDetails, jwt,
-            transformationService.transform(divorceSessionData, createEvent, EVENT_SUMMARY));
+            transformationService.transformSubmission(divorceSessionData, createEvent, EVENT_SUMMARY));
 
         try {
             draftsService.deleteDraft(jwt);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/service/TransformationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/service/TransformationService.java
@@ -5,5 +5,7 @@ import uk.gov.hmcts.reform.divorce.transformservice.domain.model.ccd.CaseDataCon
 import uk.gov.hmcts.reform.divorce.transformservice.domain.model.divorceapplicationdata.DivorceSession;
 
 public interface TransformationService {
-    CaseDataContent transform(DivorceSession divorceSession, CreateEvent createEvent, String eventSummary);
+    CaseDataContent transformSubmission(DivorceSession divorceSession, CreateEvent createEvent, String eventSummary);
+
+    CaseDataContent transformUpdate(DivorceSession divorceSession, CreateEvent createEvent, String eventSummary);
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/service/UpdateService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/service/UpdateService.java
@@ -48,7 +48,7 @@ public class UpdateService {
             divorceEventSessionData.getEventId());
 
         CaseEvent caseEvent = updateCcdEventClient.createCaseEvent(userDetails, jwt, caseId,
-            transformationService.transform(divorceEventSessionData.getEventData(), createEvent, EVENT_SUMMARY));
+            transformationService.transformUpdate(divorceEventSessionData.getEventData(), createEvent, EVENT_SUMMARY));
 
         try {
             draftsService.deleteDraft(jwt);

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/controller/CcdSubmissionControllerUpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/controller/CcdSubmissionControllerUpdateTest.java
@@ -70,10 +70,8 @@ public class CcdSubmissionControllerUpdateTest {
         final String jwt = "Bearer hgsdja87wegqeuf...";
         final Long caseId = 123567L;
         final DivorceSession divorceSession = new DivorceSession();
+
         final DivorceEventSession divorceEventSession = new DivorceEventSession();
-
-        divorceSession.setPetitionerFirstName("Dan");
-
         divorceEventSession.setEventData(divorceSession);
         divorceEventSession.setEventId("paymentMade");
 
@@ -100,10 +98,8 @@ public class CcdSubmissionControllerUpdateTest {
         final String jwt = "Bearer hgsdja87wegqeuf...";
         final Long caseId = 123567L;
         final DivorceSession divorceSession = new DivorceSession();
+
         final DivorceEventSession divorceEventSession = new DivorceEventSession();
-
-        divorceSession.setPetitionerFirstName("Dan");
-
         divorceEventSession.setEventData(divorceSession);
         divorceEventSession.setEventId("paymentMade");
 
@@ -138,10 +134,8 @@ public class CcdSubmissionControllerUpdateTest {
 
         final Long caseId = 123567L;
         final DivorceSession divorceSession = new DivorceSession();
+
         final DivorceEventSession divorceEventSession = new DivorceEventSession();
-
-        divorceSession.setPetitionerFirstName("Dan");
-
         divorceEventSession.setEventData(divorceSession);
         divorceEventSession.setEventId("paymentMade");
 
@@ -174,9 +168,8 @@ public class CcdSubmissionControllerUpdateTest {
 
         final Long caseId = 123567L;
         final DivorceSession divorceSession = new DivorceSession();
-        final DivorceEventSession divorceEventSession = new DivorceEventSession();
-        divorceSession.setPetitionerFirstName("Dan");
 
+        final DivorceEventSession divorceEventSession = new DivorceEventSession();
         divorceEventSession.setEventData(divorceSession);
         divorceEventSession.setEventId("paymentMade");
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/controller/RootControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/controller/RootControllerTest.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.reform.divorce.transformservice.controller;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -11,7 +11,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.divorce.CaseProgressionApplication;
 
@@ -19,19 +18,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(RootController.class)
+@AutoConfigureMockMvc
 @ContextConfiguration(classes = CaseProgressionApplication.class)
 public class RootControllerTest {
 
     @Autowired
     private WebApplicationContext applicationContext;
 
+    @Autowired
     private MockMvc mvc;
-
-    @Before
-    public void setUp() throws Exception {
-        mvc = MockMvcBuilders.webAppContextSetup(applicationContext).build();
-    }
-
+    
     @Test
     public void getShouldReturn200() throws Exception {
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/functional/CaseUpdateFunctionalTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/functional/CaseUpdateFunctionalTest.java
@@ -452,7 +452,6 @@ public class CaseUpdateFunctionalTest {
     private void caseUpdateStub(final String filePath) throws Exception {
         String requestBody = FileUtils.readFileToString(new File(getClass().getResource(filePath).toURI()),
             Charset.defaultCharset());
-        JSONObject requestBodyWithCreatedDate = populateCreatedDate(requestBody);
 
         String responseBody = FileUtils.readFileToString(
             new File(getClass().getResource("/fixtures/ccd/case-event-creation-201-response.json").toURI()),
@@ -462,7 +461,7 @@ public class CaseUpdateFunctionalTest {
         String url = String.join("/", CCD_CITIZENS_ENDPOINT, USER_ID, "jurisdictions", JURISDICTION,
             "case-types", CASE_TYPE_ID, "cases", CASE_ID, "events?ignore-warning=true");
 
-        ccdServer.stubFor(post(url).withRequestBody(equalToJson(requestBodyWithCreatedDate.toString()))
+        ccdServer.stubFor(post(url).withRequestBody(equalToJson(requestBody.toString()))
             .withHeader(AUTHORIZATION_HEADER_KEY, equalTo("Bearer " + JWT))
             .withHeader(SERVICE_AUTHORIZATION_HEADER_KEY, equalTo(SERVICE_TOKEN))
             .withHeader("Content-type", equalTo("application/json;charset=UTF-8"))
@@ -489,13 +488,11 @@ public class CaseUpdateFunctionalTest {
         String requestBody = FileUtils.readFileToString(
             new File(getClass().getResource(filePath).toURI()), Charset.defaultCharset());
 
-        JSONObject requestBodyWithCreatedDate = populateCreatedDate(requestBody);
-
         String url = String.join("/", CCD_CITIZENS_ENDPOINT, USER_ID, "jurisdictions", JURISDICTION,
             "case-types", CASE_TYPE_ID, "cases", CASE_ID, "events?ignore-warning=true");
 
         ccdServer.verify(postRequestedFor(urlEqualTo(url))
-            .withRequestBody(equalToJson(requestBodyWithCreatedDate.toString()))
+            .withRequestBody(equalToJson(requestBody.toString()))
             .withHeader(AUTHORIZATION_HEADER_KEY, equalTo("Bearer " + JWT))
             .withHeader(SERVICE_AUTHORIZATION_HEADER_KEY, equalTo(SERVICE_TOKEN))
             .withHeader("Content-type", equalTo("application/json;charset=UTF-8")));
@@ -565,12 +562,10 @@ public class CaseUpdateFunctionalTest {
             Charset.defaultCharset()
         );
 
-        JSONObject requestBodyWithCreatedDate = populateCreatedDate(requestBody);
-
         String url = String.join("/", CCD_CITIZENS_ENDPOINT, USER_ID, "jurisdictions", JURISDICTION,
             "case-types", CASE_TYPE_ID, "cases", CASE_ID, "events?ignore-warning=true");
 
-        ccdServer.stubFor(post(url).withRequestBody(equalToJson(requestBodyWithCreatedDate.toString()))
+        ccdServer.stubFor(post(url).withRequestBody(equalToJson(requestBody.toString()))
             .withHeader(AUTHORIZATION_HEADER_KEY, equalTo("Bearer " + JWT))
             .withHeader(SERVICE_AUTHORIZATION_HEADER_KEY, equalTo(SERVICE_TOKEN))
             .withHeader("Content-type", equalTo("application/json;charset=UTF-8"))
@@ -584,22 +579,13 @@ public class CaseUpdateFunctionalTest {
             Charset.defaultCharset()
         );
 
-        JSONObject requestBodyWithCreatedDate = populateCreatedDate(requestBody);
-
         String url = String.join("/", CCD_CITIZENS_ENDPOINT, USER_ID, "jurisdictions", JURISDICTION,
             "case-types", CASE_TYPE_ID, "cases", CASE_ID, "events?ignore-warning=true");
 
         ccdServer.verify(postRequestedFor(urlEqualTo(url))
-            .withRequestBody(equalToJson(requestBodyWithCreatedDate.toString()))
+            .withRequestBody(equalToJson(requestBody.toString()))
             .withHeader(AUTHORIZATION_HEADER_KEY, equalTo("Bearer " + JWT))
             .withHeader(SERVICE_AUTHORIZATION_HEADER_KEY, equalTo(SERVICE_TOKEN))
             .withHeader("Content-type", equalTo("application/json;charset=UTF-8")));
-    }
-
-    private JSONObject populateCreatedDate(String requestBody) throws JSONException {
-        JSONObject requestBodyJson = new JSONObject(requestBody);
-        JSONObject data = (JSONObject) requestBodyJson.get("data");
-        data.put("createdDate", LocalDate.now().format(ofPattern("yyyy-MM-dd")));
-        return requestBodyJson;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/AddressesCaseToCCDMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/AddressesCaseToCCDMapperTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 public class AddressesCaseToCCDMapperTest {
 
     @Autowired
-    private DivorceCaseToCCDMapper mapper;
+    private DivorceCaseToCCDSubmissionMapper mapper;
 
     @Test
     public void shouldMapAllAndTransformAllFieldsForAdulteryDifferentAddressMappingScenario()

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/D8DocumentCaseToCCDMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/D8DocumentCaseToCCDMapperTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 public class D8DocumentCaseToCCDMapperTest {
 
     @Autowired
-    private DivorceCaseToCCDMapper mapper;
+    private DivorceCaseToCCDSubmissionMapper mapper;
 
     @Test
     public void shouldMapAllAndTransformAllFieldsForD8DocumentGenerated() throws URISyntaxException, IOException {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/HowNameChangedCaseToCCDMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/HowNameChangedCaseToCCDMapperTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 public class HowNameChangedCaseToCCDMapperTest {
 
     @Autowired
-    private DivorceCaseToCCDMapper mapper;
+    private DivorceCaseToCCDSubmissionMapper mapper;
 
     @Test
     public void shouldMapAllAndTransformAllFieldsForHowNameChangedMappingScenario()

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/JurisdictionAllCaseToCCDMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/JurisdictionAllCaseToCCDMapperTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 public class JurisdictionAllCaseToCCDMapperTest {
 
     @Autowired
-    private DivorceCaseToCCDMapper mapper;
+    private DivorceCaseToCCDSubmissionMapper mapper;
 
     @Test
     public void shouldMapAllAndTransformAllFieldsForJurisdictionAllScenario() throws URISyntaxException, IOException {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/JurisdictionSixTwelveCaseToCCDMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/JurisdictionSixTwelveCaseToCCDMapperTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 public class JurisdictionSixTwelveCaseToCCDMapperTest {
 
     @Autowired
-    private DivorceCaseToCCDMapper mapper;
+    private DivorceCaseToCCDSubmissionMapper mapper;
 
     @Test
     public void shouldMapAllAndTransformAllFieldsForJurisdiction612Scenario() throws URISyntaxException, IOException {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/PaymentCaseToCCDMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/PaymentCaseToCCDMapperTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 public class PaymentCaseToCCDMapperTest {
 
     @Autowired
-    private DivorceCaseToCCDMapper mapper;
+    private DivorceCaseToCCDSubmissionMapper mapper;
 
     @Test
     public void shouldMapAllAndTransformAllFieldsForPaymentsMappingScenario() throws URISyntaxException, IOException {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/ReasonAdulteryCaseToCCDMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/ReasonAdulteryCaseToCCDMapperTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 public class ReasonAdulteryCaseToCCDMapperTest {
 
     @Autowired
-    private DivorceCaseToCCDMapper mapper;
+    private DivorceCaseToCCDSubmissionMapper mapper;
 
     @Test
     public void shouldMapAllAndTransformAllFieldsForReasonAdulteryScenario() throws URISyntaxException, IOException {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/ReasonDesertionCaseToCCDMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/ReasonDesertionCaseToCCDMapperTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 public class ReasonDesertionCaseToCCDMapperTest {
 
     @Autowired
-    private DivorceCaseToCCDMapper mapper;
+    private DivorceCaseToCCDSubmissionMapper mapper;
 
     @Test
     public void shouldMapAllAndTransformAllFieldsForReasonDesertionScenario() throws URISyntaxException, IOException {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/ReasonSeparationCaseToCCDMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/ReasonSeparationCaseToCCDMapperTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 public class ReasonSeparationCaseToCCDMapperTest {
 
     @Autowired
-    private DivorceCaseToCCDMapper mapper;
+    private DivorceCaseToCCDSubmissionMapper mapper;
 
     @Test
     public void shouldMapAllAndTransformAllFieldsForReasonSeparationScenario() throws URISyntaxException, IOException {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/ReasonUnreasonableBehaviourCaseToCCDMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/ReasonUnreasonableBehaviourCaseToCCDMapperTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 public class ReasonUnreasonableBehaviourCaseToCCDMapperTest extends DivorceCaseToCCDMapperTestUtil {
 
     @Autowired
-    private DivorceCaseToCCDMapper mapper;
+    private DivorceCaseToCCDSubmissionMapper mapper;
 
     @Test
     public void shouldMapAllAndTransformAllFieldsForReasonUnreasonableBehaviourScenario()

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/SameSexCaseToCCDMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/mapping/SameSexCaseToCCDMapperTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 public class SameSexCaseToCCDMapperTest {
 
     @Autowired
-    private DivorceCaseToCCDMapper mapper;
+    private DivorceCaseToCCDSubmissionMapper mapper;
 
     @Test
     public void shouldMapAllAndTransformAllFieldsForSameSexScenario() throws URISyntaxException, IOException {

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/service/DivorceToCcdTransformationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/service/DivorceToCcdTransformationServiceTest.java
@@ -12,8 +12,13 @@ import uk.gov.hmcts.reform.divorce.transformservice.domain.model.ccd.CaseDataCon
 import uk.gov.hmcts.reform.divorce.transformservice.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.transformservice.domain.model.divorceapplicationdata.DivorceSession;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 @RunWith(SpringRunner.class)
@@ -22,23 +27,94 @@ import static org.mockito.Mockito.mock;
 public class DivorceToCcdTransformationServiceTest {
     @Autowired
     private DivorceToCcdTransformationService transformationService;
+    private static final String TOKEN = "_token";
+    private static final String EVENT_ID = "event-id";
+    private static final String EVENT_SUMMARY = "event-summary";
 
     @Test
-    public void shouldTransformDivorceSessionToCaseDataContent() {
-        String token = "_token";
-        String eventId = "event-id";
-        String eventSummary = "event-summary";
+    public void shouldTransformDivorceSessionTokenAndEventDetailsToCaseDataContentWhenSubmitting() {
 
         DivorceSession divorceSession = mock(DivorceSession.class);
         CaseDetails caseDetails = new CaseDetails();
 
-        CreateEvent createEvent = new CreateEvent(token, eventId, caseDetails);
+        CreateEvent createEvent = new CreateEvent(TOKEN, EVENT_ID, caseDetails);
 
-        CaseDataContent caseDataContent = transformationService.transform(divorceSession, createEvent, eventSummary);
+        CaseDataContent caseDataContent = transformationService
+            .transformSubmission(divorceSession, createEvent, EVENT_SUMMARY);
 
-        assertThat(caseDataContent.getToken(), equalTo(token));
-        assertThat(caseDataContent.getEvent().getEventId(), equalTo(eventId));
-        assertThat(caseDataContent.getEvent().getSummary(), equalTo(eventSummary));
+        assertThat(caseDataContent.getToken(), equalTo(TOKEN));
+        assertThat(caseDataContent.getEvent().getEventId(), equalTo(EVENT_ID));
+        assertThat(caseDataContent.getEvent().getSummary(), equalTo(EVENT_SUMMARY));
+    }
 
+    @Test
+    public void shouldTransformDivorceSessionTokenAndEventDetailsToCaseDataContentWhenUpdating() {
+
+        DivorceSession divorceSession = mock(DivorceSession.class);
+        CaseDetails caseDetails = new CaseDetails();
+
+        CreateEvent createEvent = new CreateEvent(TOKEN, EVENT_ID, caseDetails);
+
+        CaseDataContent caseDataContent = transformationService
+            .transformUpdate(divorceSession, createEvent, EVENT_SUMMARY);
+
+        assertThat(caseDataContent.getToken(), equalTo(TOKEN));
+        assertThat(caseDataContent.getEvent().getEventId(), equalTo(EVENT_ID));
+        assertThat(caseDataContent.getEvent().getSummary(), equalTo(EVENT_SUMMARY));
+    }
+
+    @Test
+    public void shouldSetCurrentDateWhenTransformingSubmissionData() {
+
+        // given
+        DivorceSession divorceSession = mock(DivorceSession.class);
+        CaseDetails caseDetails = new CaseDetails();
+
+        CreateEvent createEvent = new CreateEvent(TOKEN, EVENT_ID, caseDetails);
+
+        // when
+        CaseDataContent caseDataContent = transformationService
+            .transformSubmission(divorceSession, createEvent, EVENT_SUMMARY);
+
+        // then
+        assertThat(caseDataContent.getData().get("createdDate"),
+            equalTo(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")).toString()));
+    }
+
+    @Test
+    public void shouldNotSetCurrentDateWhenTransformingUpdateData() {
+
+        // given
+        DivorceSession divorceSession = mock(DivorceSession.class);
+        CaseDetails caseDetails = new CaseDetails();
+
+        CreateEvent createEvent = new CreateEvent(TOKEN, EVENT_ID, caseDetails);
+
+        // when
+        CaseDataContent caseDataContent = transformationService
+            .transformUpdate(divorceSession, createEvent, EVENT_SUMMARY);
+
+        // then
+        assertNull(caseDataContent.getData().get("createdDate"));
+    }
+
+    @Test
+    public void shouldTransformDivorceSessionDataWhenSubmitting() {
+
+        // given
+        DivorceSession divorceSession = new DivorceSession();
+        String petitionerPhoneNumber = "07724879304";
+        divorceSession.setPetitionerPhoneNumber(petitionerPhoneNumber);
+
+        CaseDetails caseDetails = new CaseDetails();
+
+        CreateEvent createEvent = new CreateEvent(TOKEN, EVENT_ID, caseDetails);
+
+        // when
+        CaseDataContent caseDataContent = transformationService
+            .transformSubmission(divorceSession, createEvent, EVENT_SUMMARY);
+
+        // then
+        assertEquals(petitionerPhoneNumber, caseDataContent.getData().get("D8PetitionerPhoneNumber"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/service/SubmissionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/service/SubmissionServiceTest.java
@@ -59,13 +59,14 @@ public class SubmissionServiceTest {
 
         when(userService.getUserDetails(jwt)).thenReturn(userDetails);
         when(ccdClient.createCase(userDetails, jwt, divorceSession)).thenReturn(createEvent);
-        when(transformationService.transform(divorceSession, createEvent, eventSummary)).thenReturn(caseDataContent);
+        when(transformationService
+            .transformSubmission(divorceSession, createEvent, eventSummary)).thenReturn(caseDataContent);
         when(ccdClient.submitCase(userDetails, jwt, caseDataContent)).thenReturn(submitEvent);
 
         assertThat(submissionService.submit(divorceSession, jwt)).isEqualTo(caseId);
 
         verify(ccdClient).createCase(userDetails, jwt, divorceSession);
-        verify(transformationService).transform(divorceSession, createEvent, eventSummary);
+        verify(transformationService).transformSubmission(divorceSession, createEvent, eventSummary);
         verify(ccdClient).submitCase(userDetails, jwt, caseDataContent);
         verifyNoMoreInteractions(ccdClient, transformationService);
     }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/service/UpdateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/service/UpdateServiceTest.java
@@ -79,14 +79,14 @@ public class UpdateServiceTest {
         caseEvent.setCaseId(caseId);
 
         when(ccdEventClient.startEvent(userDetails, jwt, caseId, eventId)).thenReturn(createEvent);
-        when(transformationService.transform(divorceEventSession.getEventData(), createEvent, eventSummary))
+        when(transformationService.transformUpdate(divorceEventSession.getEventData(), createEvent, eventSummary))
             .thenReturn(caseDataContent);
         when(ccdEventClient.createCaseEvent(userDetails, jwt, caseId, caseDataContent)).thenReturn(caseEvent);
 
         assertThat(updateService.update(caseId, divorceEventSession, jwt)).isEqualTo(caseId);
 
         verify(ccdEventClient).startEvent(userDetails, jwt, caseId, eventId);
-        verify(transformationService).transform(divorceEventSession.getEventData(), createEvent, eventSummary);
+        verify(transformationService).transformUpdate(divorceEventSession.getEventData(), createEvent, eventSummary);
         verify(ccdEventClient).createCaseEvent(userDetails, jwt, caseId, caseDataContent);
         verifyNoMoreInteractions(ccdEventClient, transformationService);
     }

--- a/src/test/resources/fixtures/ccd/case-event-creation-request-body.json
+++ b/src/test/resources/fixtures/ccd/case-event-creation-request-body.json
@@ -5,8 +5,6 @@
       "description" : null
     },
     "data" : {
-      "D8PetitionerFirstName" : "Dan",
-      "D8DerivedPetitionerCurrentFullName" : "Dan ",
       "D8Cohort" : "onlineSubmissionPrivateBeta"
     },
     "security_classification" : null,

--- a/src/test/resources/fixtures/divorce/update-request-body.json
+++ b/src/test/resources/fixtures/divorce/update-request-body.json
@@ -1,6 +1,5 @@
 {
     "eventData" : {
-        "petitionerFirstName": "Dan"
     },
     "eventId" : "paymentMade"
 }


### PR DESCRIPTION
Currently when a user submits a divorce application, but at another date completes payment, the application's createdDate in CCD will be set to the date when the user has completed payment. 

This is due to the same Divorce Session to CCD Case Data mapper being used for submission and update events. To solve the bug I have split out the mapper in two, stripping out properties which are not submitted in update events, as well as the setting of the current date. 

