### PR TITLE
Added StatementOfTruth to automation tests

### DIFF
--- a/automation-test/src/test/resources/divorce-payload-json/addresses.json
+++ b/automation-test/src/test/resources/divorce-payload-json/addresses.json
@@ -145,6 +145,7 @@
     }
   },
   "courts": "eastMidlands",
+  "confirmPrayer": "Yes",
   "jurisdictionConnection": [
     "A",
     "C"

--- a/automation-test/src/test/resources/divorce-payload-json/casedata-d8-payload.json
+++ b/automation-test/src/test/resources/divorce-payload-json/casedata-d8-payload.json
@@ -144,7 +144,8 @@
     "D8ReasonForDivorce": "unreasonable-behaviour",
     "D8DerivedPetitionerCurrentFullName": "John Smith",
     "D8InferredPetitionerGender": "female",
-    "D8JurisdictionHabituallyResLast6Months": "NO"
+    "D8JurisdictionHabituallyResLast6Months": "NO",
+    "D8StatementOfTruth": "YES"
   },
   "data_classification": {
     "D8DerivedRespondentHomeAddress": "PUBLIC",
@@ -280,7 +281,8 @@
     "D8ReasonForDivorce": "PUBLIC",
     "D8DerivedPetitionerCurrentFullName": "PUBLIC",
     "D8InferredPetitionerGender": "PUBLIC",
-    "D8JurisdictionHabituallyResLast6Months": "PUBLIC"
+    "D8JurisdictionHabituallyResLast6Months": "PUBLIC",
+    "D8StatementOfTruth": "PUBLIC"
   },
   "after_submit_callback_response": null,
   "callback_response_status_code": null,
@@ -419,6 +421,7 @@
     "D8ReasonForDivorce": "PUBLIC",
     "D8DerivedPetitionerCurrentFullName": "PUBLIC",
     "D8InferredPetitionerGender": "PUBLIC",
-    "D8JurisdictionHabituallyResLast6Months": "PUBLIC"
+    "D8JurisdictionHabituallyResLast6Months": "PUBLIC",
+    "D8StatementOfTruth": "PUBLIC"
   }
 }

--- a/automation-test/src/test/resources/divorce-payload-json/how-name-changed.json
+++ b/automation-test/src/test/resources/divorce-payload-json/how-name-changed.json
@@ -211,6 +211,7 @@
     }
   },
   "courts": "eastMidlands",
+  "confirmPrayer": "Yes",
   "helpWithFeesAppliedForFees": "Yes",
   "helpWithFeesReferenceNumber": "HWF-123-123",
   "jurisdictionConnection": [

--- a/automation-test/src/test/resources/divorce-payload-json/jurisdiction-6-12.json
+++ b/automation-test/src/test/resources/divorce-payload-json/jurisdiction-6-12.json
@@ -209,6 +209,7 @@
     }
   },
   "courts": "eastMidlands",
+  "confirmPrayer": "Yes",
   "postcodeLookup": {
     "postcodeError": "false"
   },

--- a/automation-test/src/test/resources/divorce-payload-json/jurisdiction-all.json
+++ b/automation-test/src/test/resources/divorce-payload-json/jurisdiction-all.json
@@ -208,6 +208,7 @@
     }
   },
   "courts": "eastMidlands",
+  "confirmPrayer": "Yes",
   "paymentMethod": "card-phone-court",
   "paymentTimeToCall": "afternoon",
   "paymentPhoneNumber": "01234567890",

--- a/automation-test/src/test/resources/divorce-payload-json/reason-adultery.json
+++ b/automation-test/src/test/resources/divorce-payload-json/reason-adultery.json
@@ -216,6 +216,7 @@
     }
   },
   "courts": "westMidlands",
+  "confirmPrayer": "Yes",
   "reasonForDivorceAdulteryWishToName": "Yes",
   "reasonForDivorceAdultery3rdPartyFirstName": "Jennifer",
   "reasonForDivorceAdultery3rdPartyLastName": "Lawrence",

--- a/automation-test/src/test/resources/divorce-payload-json/reason-desertion.json
+++ b/automation-test/src/test/resources/divorce-payload-json/reason-desertion.json
@@ -207,6 +207,7 @@
     }
   },
   "courts": "southWest",
+  "confirmPrayer": "Yes",
   "reasonForDivorceDesertionDay": 1,
   "reasonForDivorceDesertionMonth": 2,
   "reasonForDivorceDesertionYear": 2015,

--- a/automation-test/src/test/resources/divorce-payload-json/reason-separation.json
+++ b/automation-test/src/test/resources/divorce-payload-json/reason-separation.json
@@ -207,6 +207,7 @@
     }
   },
   "courts": "westMidlands",
+  "confirmPrayer": "Yes",
   "postcodeLookup": {
     "postcodeError": "false"
   },

--- a/automation-test/src/test/resources/divorce-payload-json/reason-unreasonable-behaviour.json
+++ b/automation-test/src/test/resources/divorce-payload-json/reason-unreasonable-behaviour.json
@@ -220,5 +220,6 @@
     }
   },
   "courts": "eastMidlands",
+  "confirmPrayer": "Yes",
   "sessionKey": "744e590518fd5a8114fe6c280df7ef9488b9b29c839ea08eef567cda752369b3:f0e0d0b7c03d6d0ffaf0e302f1c385d0:1f29a3d9dd276937ebdc06fff8fa8424c9bac0a15ab881feb518fb5e31d6fc09a37615ba5f728e99676810c40510ab80e9719aa1d595bb45a18709f47e9d9102"
 }

--- a/automation-test/src/test/resources/divorce-payload-json/same-sex.json
+++ b/automation-test/src/test/resources/divorce-payload-json/same-sex.json
@@ -204,6 +204,7 @@
     }
   },
   "courts": "eastMidlands",
+  "confirmPrayer": "Yes",
   "jurisdictionConnection": [
     "A",
     "C"

--- a/automation-test/src/test/resources/divorce-payload-json/submit-complete-case.json
+++ b/automation-test/src/test/resources/divorce-payload-json/submit-complete-case.json
@@ -6,7 +6,7 @@
     "httpOnly": true,
     "path": "/"
   },
-    "confirmPrayer" : "Yes",
+  "confirmPrayer" : "Yes",
   "expires": 1507916960537,
   "screenHasMarriageBroken": "Yes",
   "screenHasRespondentAddress": "Yes",

--- a/automation-test/src/test/resources/divorce-payload-json/update-addresses.json
+++ b/automation-test/src/test/resources/divorce-payload-json/update-addresses.json
@@ -147,6 +147,7 @@
           }
         },
         "courts": "eastMidlands",
+        "confirmPrayer": "Yes",
         "jurisdictionConnection": [
           "A",
           "C"


### PR DESCRIPTION
Cases created through the automated functional tests are missing StatementOfTruth. When trying to issue one of these cases Validation Service throws an error as it is a mandatory field.