### PR TITLE
[PREVIEW] STOPGAP WIP: May not be required: Stop submission if duplicate case found

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,7 +215,8 @@ sonarqube {
     properties {
         property "sonar.exclusions", "**uk/gov/hmcts/reform/divorce/**/domain/**/*, " +
             "**uk/gov/hmcts/reform/divorce/pay/models/**/*, **uk/gov/hmcts/reform/divorce/fees/models/**/*," +
-            "**uk/gov/hmcts/reform/divorce/pay/exceptions/**/*,**uk/gov/hmcts/reform/divorce/support/**/*"
+            "**uk/gov/hmcts/reform/divorce/pay/exceptions/**/*,**uk/gov/hmcts/reform/divorce/support/**/*," +
+            "**uk/gov/hmcts/reform/divorce/transformservice/exception/**/*"
         property "sonar.jacoco.reportPath", "${project.buildDir}/jacoco.exec"
         property "sonar.projectKey", "DivorceCaseProgressionService"
         property "sonar.projectName", "Divorce :: case-progression-service"

--- a/src/main/java/uk/gov/hmcts/reform/divorce/draftservice/service/DraftsRetrievalService.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/draftservice/service/DraftsRetrievalService.java
@@ -39,7 +39,7 @@ class DraftsRetrievalService {
         List<Map<String, Object>> caseData = retrieveCcdClient.getCases(userId, jwt);
 
         if (CollectionUtils.isNotEmpty(caseData)) {
-            log.info("Checking CCD for an existing case as draft not found for userId {}", userId);
+            log.info("Checking CCD for an existing case for userId {}", userId);
             return DraftResponseFactory.buildDraftResponseFromCaseData(caseData);
         } else {
             DraftList draftList = draftStoreClient.getAll(jwt, secret);

--- a/src/main/java/uk/gov/hmcts/reform/divorce/errorhandler/SubmissionExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/errorhandler/SubmissionExceptionHandler.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.divorce.draftservice.controller.DraftsController;
 import uk.gov.hmcts.reform.divorce.draftservice.exception.DraftStoreUnavailableException;
 import uk.gov.hmcts.reform.divorce.transformservice.controller.CcdSubmissionController;
 import uk.gov.hmcts.reform.divorce.transformservice.domain.transformservice.CCDResponse;
+import uk.gov.hmcts.reform.divorce.transformservice.exception.DuplicateCaseException;
 
 import java.text.MessageFormat;
 import java.time.format.DateTimeParseException;
@@ -130,6 +131,11 @@ public class SubmissionExceptionHandler {
     @ExceptionHandler(DraftStoreUnavailableException.class)
     public ResponseEntity<Void> handleDraftStoreUnavailable() {
         return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @ExceptionHandler(DuplicateCaseException.class)
+    public ResponseEntity<Void> handleDuplicateCaseException() {
+        return new ResponseEntity<>(HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
     private boolean isDraftsRequest(HttpServletRequest request) {

--- a/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/client/RetrieveCcdClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/client/RetrieveCcdClient.java
@@ -11,10 +11,15 @@ import org.springframework.web.client.RestTemplate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Component
 @Slf4j
 public class RetrieveCcdClient {
+
+    private static final String CASE_STATE_KEY = "state";
+    private static final String REJECTED_STATE = "Rejected";
 
     private final CcdClientConfiguration ccdClientConfiguration;
     private final RestTemplate restTemplate;
@@ -46,7 +51,21 @@ public class RetrieveCcdClient {
             return Collections.emptyList();
         }
 
+        log.info(cases.toString());
         log.info(String.format("Found %s cases for userId %s", cases.size(), userId));
+
+        return cases;
+    }
+
+    public List<Map<String, Object>> getNonRejectedCases(String userId, String jwt) {
+        List<Map<String, Object>> cases = getCases(userId, jwt)
+            .stream()
+            .filter(Objects::nonNull)
+            .filter(ccdCase ->
+                !ccdCase.get(CASE_STATE_KEY).toString().equalsIgnoreCase(REJECTED_STATE)
+            ).collect(Collectors.toList());
+
+        log.info(String.format("Found %s non-rejected cases for userId %s", cases.size(), userId));
 
         return cases;
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/exception/DuplicateCaseException.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/transformservice/exception/DuplicateCaseException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.divorce.transformservice.exception;
+
+public class DuplicateCaseException extends RuntimeException {
+    public DuplicateCaseException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/client/RetrieveCcdClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/client/RetrieveCcdClientTest.java
@@ -11,7 +11,9 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -27,6 +29,10 @@ public class RetrieveCcdClientTest {
     private static final String USER_ID = "userId";
     private static final String JWT = "jwt";
     private static final String EXPECTED_URL = "http://expectedUrl";
+    private static final String CASE_STATE_KEY = "state";
+    private static final String REJECTED_STATE = "Rejected";
+    private static final String SUBMITTED_STATE = "Submitted";
+
     @Mock
     private CcdClientConfiguration mockClientConfiguration;
     @Mock
@@ -116,6 +122,75 @@ public class RetrieveCcdClientTest {
         given(mockResponseEntity.getBody()).willReturn(listOfCases);
         given(underTest
             .getCases(USER_ID, JWT))
+            .willReturn(listOfCases);
+
+        //when
+        List<Map<String, Object>> casesRetrieved = underTest.getCases(USER_ID, JWT);
+
+        //then
+        assertEquals(0, casesRetrieved.size());
+    }
+
+    @Test
+    public void getNonRejectedCases_should_return_list_of_non_rejected_cases() {
+
+        //given
+        Map<String, Object> submittedCase = new HashMap<>();
+        submittedCase.put(CASE_STATE_KEY, SUBMITTED_STATE);
+
+        Map<String, Object> rejectedCase = new HashMap<>();
+        rejectedCase.put(CASE_STATE_KEY, REJECTED_STATE);
+
+        List<Map<String, Object>> expectedListOfCases = new ArrayList<>();
+        expectedListOfCases.add(submittedCase);
+
+        List<Map<String, Object>> responseListOfCases = new ArrayList<>();
+        responseListOfCases.add(submittedCase);
+        responseListOfCases.add(rejectedCase);
+
+        given(mockResponseEntity.getBody()).willReturn(responseListOfCases);
+        given(mockRestTemplate.exchange(EXPECTED_URL,
+            HttpMethod.GET,
+            mockHttpEntity,
+            List.class))
+            .willReturn(mockResponseEntity);
+
+        // when
+        listOfCases = underTest.getNonRejectedCases(USER_ID, JWT);
+
+        // then
+        assertEquals(expectedListOfCases, listOfCases);
+    }
+
+    @Test
+    public void getNonRejectedCases_should_return_empty_list_if_only_rejected_cases_found() {
+        //given
+        Map<String, Object> rejectedCase = new HashMap<>();
+        rejectedCase.put(CASE_STATE_KEY, REJECTED_STATE);
+
+        List<Map<String, Object>> listOfCases = new ArrayList<>();
+        listOfCases.add(rejectedCase);
+
+        given(mockResponseEntity.getBody()).willReturn(listOfCases);
+        given(underTest
+            .getNonRejectedCases(USER_ID, JWT))
+            .willReturn(listOfCases);
+
+        //when
+        List<Map<String, Object>> casesRetrieved = underTest.getNonRejectedCases(USER_ID, JWT);
+
+        //then
+        assertEquals(0, casesRetrieved.size());
+    }
+
+
+    @Test
+    public void getNonRejectedCases_should_return_empty_list_if_no_cases_found() {
+        //given
+        listOfCases = Collections.emptyList();
+        given(mockResponseEntity.getBody()).willReturn(listOfCases);
+        given(underTest
+            .getNonRejectedCases(USER_ID, JWT))
             .willReturn(listOfCases);
 
         //when

--- a/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/service/SubmissionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/transformservice/service/SubmissionServiceTest.java
@@ -8,11 +8,19 @@ import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.divorce.draftservice.service.DraftsService;
 import uk.gov.hmcts.reform.divorce.idam.models.UserDetails;
 import uk.gov.hmcts.reform.divorce.idam.services.UserService;
+import uk.gov.hmcts.reform.divorce.transformservice.client.RetrieveCcdClient;
 import uk.gov.hmcts.reform.divorce.transformservice.client.SubmitCcdClient;
 import uk.gov.hmcts.reform.divorce.transformservice.domain.ccd.CreateEvent;
 import uk.gov.hmcts.reform.divorce.transformservice.domain.ccd.SubmitEvent;
 import uk.gov.hmcts.reform.divorce.transformservice.domain.model.ccd.CaseDataContent;
 import uk.gov.hmcts.reform.divorce.transformservice.domain.model.divorceapplicationdata.DivorceSession;
+import uk.gov.hmcts.reform.divorce.transformservice.exception.DuplicateCaseException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -39,6 +47,9 @@ public class SubmissionServiceTest {
     @Mock
     private UserService userService;
 
+    @Mock
+    private RetrieveCcdClient retrieveCcdClient;
+
     @InjectMocks
     private SubmissionService submissionService;
 
@@ -58,6 +69,7 @@ public class SubmissionServiceTest {
         submitEvent.setCaseId(caseId);
 
         when(userService.getUserDetails(jwt)).thenReturn(userDetails);
+        when(retrieveCcdClient.getNonRejectedCases(userId, jwt)).thenReturn(Collections.emptyList());
         when(ccdClient.createCase(userDetails, jwt, divorceSession)).thenReturn(createEvent);
         when(transformationService
             .transformSubmission(divorceSession, createEvent, eventSummary)).thenReturn(caseDataContent);
@@ -65,21 +77,43 @@ public class SubmissionServiceTest {
 
         assertThat(submissionService.submit(divorceSession, jwt)).isEqualTo(caseId);
 
+        verify(retrieveCcdClient).getNonRejectedCases(userId, jwt);
         verify(ccdClient).createCase(userDetails, jwt, divorceSession);
         verify(transformationService).transformSubmission(divorceSession, createEvent, eventSummary);
         verify(ccdClient).submitCase(userDetails, jwt, caseDataContent);
         verifyNoMoreInteractions(ccdClient, transformationService);
     }
 
+    @Test(expected = DuplicateCaseException.class)
+    public void submitShouldThrowDuplicateCaseExceptionWhenCcdCaseIsFound() throws Exception {
+        String jwt = "_jwt";
+        String userId = "60";
+        UserDetails userDetails = UserDetails.builder().id(userId).build();
+        List<Map<String, Object>> ccdCases = new ArrayList<>();
+        ccdCases.add(new HashMap<>());
+        when(userService.getUserDetails(jwt)).thenReturn(userDetails);
+        when(retrieveCcdClient.getNonRejectedCases(userId, jwt)).thenReturn(ccdCases);
+
+        DivorceSession divorceSession = new DivorceSession();
+
+        submissionService.submit(divorceSession, jwt);
+
+        verify(userService).getUserDetails(jwt);
+        verify(retrieveCcdClient).getNonRejectedCases(userId, jwt);
+    }
+
     @Test
     public void submitShouldDeleteTheDivorceDraftAfterSubmissionToCCD() {
-        DivorceSession divorceSession = new DivorceSession();
-        String jwt = "_jwt";
-
         SubmitEvent submitEvent = new SubmitEvent();
         submitEvent.setCaseId(1);
 
+        UserDetails userDetails = UserDetails.builder().id("1").build();
+        when(userService.getUserDetails(anyString())).thenReturn(userDetails);
+        when(retrieveCcdClient.getNonRejectedCases(anyString(), anyString())).thenReturn(Collections.emptyList());
         when(ccdClient.submitCase(any(), anyString(), any())).thenReturn(submitEvent);
+
+        DivorceSession divorceSession = new DivorceSession();
+        String jwt = "_jwt";
 
         submissionService.submit(divorceSession, jwt);
 
@@ -90,9 +124,11 @@ public class SubmissionServiceTest {
     public void submitShouldNotFailWhenDeletingTheDraftFails() {
         DivorceSession divorceSession = new DivorceSession();
         String jwt = "_jwt";
+        String userId = "1";
 
-        UserDetails userDetails = UserDetails.builder().id("1").build();
+        UserDetails userDetails = UserDetails.builder().id(userId).build();
         when(userService.getUserDetails(jwt)).thenReturn(userDetails);
+        when(retrieveCcdClient.getNonRejectedCases(userId, jwt)).thenReturn(Collections.emptyList());
 
         SubmitEvent submitEvent = new SubmitEvent();
         submitEvent.setCaseId(1);


### PR DESCRIPTION
A quick fix to stop duplicate case issues. This prevents the user from ever creating a case through the CPS submit endpoint (which frontend uses) if it detects there is a non-rejected case in CCD already.

The user will get a generic-error page unfortunately, but this PR is a stop gap measure.
Pending functional tests (unit tests and coverage done, integration tests not required).