### PR TITLE
[PREVIEW] Update Integration tests to be compatible with SIDAM

### DIFF
--- a/automation-test/build.gradle
+++ b/automation-test/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 
-    testCompile group: 'uk.gov.hmcts.reform', name: 'java-logging', version:'2.0.2'
+    testCompile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: '2.0.2'
     testCompile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.6.0'
     testCompile project(':test-support')
 }

--- a/automation-test/src/test/resources/application-aat.properties
+++ b/automation-test/src/test/resources/application-aat.properties
@@ -1,3 +1,4 @@
 ccd.caseDataStore.baseUrl=http://ccd-data-store-api-aat.service.core-compute-aat.internal
 
 auth.idam.client.baseUrl=https://preprod-idamapi.reform.hmcts.net:3511
+auth.idam.client.redirectUri=https://div-pfe-aat.service.core-compute-aat.internal/authenticated

--- a/automation-test/src/test/resources/application-preview.properties
+++ b/automation-test/src/test/resources/application-preview.properties
@@ -1,5 +1,6 @@
 ccd.caseDataStore.baseUrl=http://ccd-data-store-api-aat.service.core-compute-aat.internal
 
 auth.idam.client.baseUrl=https://preprod-idamapi.reform.hmcts.net:3511
+auth.idam.client.redirectUri=https://div-pfe-aat.service.core-compute-aat.internal/authenticated
 
 auth.provider.service.client.baseUrl=http://rpe-service-auth-provider-aat.service.core-compute-aat.internal

--- a/automation-test/src/test/resources/application.properties
+++ b/automation-test/src/test/resources/application.properties
@@ -4,6 +4,8 @@ logging.level.uk.gov.hmcts.reform.divorce=DEBUG
 env=${ITEST_ENVIRONMENT:local}
 
 auth.idam.client.baseUrl=http://localhost:4501
+auth.idam.client.redirectUri=https://localhost:9000/oauth2/callback
+auth.idam.client.secret=${AUTH_IDAM_CLIENT_SECRET:dummy-secret}
 auth.idam.test.invalid.jwt=Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIwOTg3NjU0MyIsInN1YiI6IjEwMCIsImlhdCI6MTUwODk0MDU3MywiZXhwIjoxNTE5MzAzNDI3LCJkYXRhIjoiY2l0aXplbiIsInR5cGUiOiJBQ0NFU1MiLCJpZCI6IjEwMCIsImZvcmVuYW1lIjoiSm9obiIsInN1cm5hbWUiOiJEb2UiLCJkZWZhdWx0LXNlcnZpY2UiOiJEaXZvcmNlIiwibG9hIjoxLCJkZWZhdWx0LXVybCI6Imh0dHBzOi8vd3d3Lmdvdi51ayIsImdyb3VwIjoiZGl2b3JjZSJ9.lkNr1vpAP5_Gu97TQa0cRtHu8I-QESzu8kMXCJOQrVU
 
 auth.provider.service.client.baseUrl=${idam_s2s_url:http://localhost:4502}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -60,6 +60,7 @@ module "div-case-progression" {
         DOCUMENT_MANAGEMENT_STORE_URL = "${local.dm_store_url}"
         IDAM_API_BASEURL = "${var.idam_api_baseurl}"
         IDAM_API_HEALTH_URI = "${var.idam_api_baseurl}/health"
+        AUTH_IDAM_CLIENT_SECRET = "${data.azurerm_key_vault_secret.idam-secret.value}"
         PAYMENT_API_BASEURL = "${local.payment_api_base_url}"
         FEES_AND_PAYMENTS_BASE_URL="${local.fees_and_payments_base_url}"
         DRAFT_CCD_CHECK_ENABLED = "${var.draft_check_ccd_enabled}"
@@ -94,5 +95,10 @@ data "azurerm_key_vault_secret" "draft-store-api-encryption-key" {
 
 data "azurerm_key_vault_secret" "uk-gov-notify-api-key" {
     name      = "uk-gov-notify-api-key"
+    vault_uri = "${data.azurerm_key_vault.div_key_vault.vault_uri}"
+}
+
+data "azurerm_key_vault_secret" "idam-secret" {
+    name      = "idam-secret"
     vault_uri = "${data.azurerm_key_vault.div_key_vault.vault_uri}"
 }

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -17,3 +17,7 @@ output "draft_store_service_url" {
 output "draft_check_ccd_enabled" {
     value = "${var.draft_check_ccd_enabled}"
 }
+
+output "auth_idam_client_secret" {
+    value = "${data.azurerm_key_vault_secret.idam-secret.value}"
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -24,6 +24,8 @@ case.progression.service.auth.secret=${AUTH_PROVIDER_SERVICE_CLIENT_KEY:fakesecr
 case.progression.auth.microservice=divorce_ccd_submission
 
 auth.idam.client.baseUrl=http://localhost:4501
+auth.idam.client.redirectUri=https://localhost:9000/oauth2/callback
+auth.idam.client.secret=${AUTH_IDAM_CLIENT_SECRET:dummy-secret}
 
 ccd.caseworker.role=caseworker-divorce
 

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -19,10 +19,12 @@ dependencies {
     compile group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     compile group: 'org.json', name:'json', version: '20140107'
     compile group: 'org.skyscreamer', name:'jsonassert', version: '1.2.3'
+    testCompile group: 'uk.gov.hmcts.reform.divorce', name: 'div-common-utils', version: '1.0.5'
 }
 
 repositories {
     mavenLocal()
+    maven { url "https://dl.bintray.com/hmcts/hmcts-maven" }
     maven { url "http://artifactory.reform.hmcts.net/artifactory/libs-release" }
     jcenter()
 }

--- a/test-support/src/main/java/uk/gov/hmcts/reform/divorce/support/auth/IdamUserSupport.java
+++ b/test-support/src/main/java/uk/gov/hmcts/reform/divorce/support/auth/IdamUserSupport.java
@@ -92,7 +92,11 @@ public class IdamUserSupport {
             .password(password)
             .forename("Test")
             .surname("User")
-            .roles(new UserCode[] { UserCode.builder().code("caseworker-divorce-courtadmin").build() })
+            .roles(new UserCode[] {
+                UserCode.builder().code("caseworker").build(),
+                UserCode.builder().code("caseworker-divorce").build(),
+                UserCode.builder().code("caseworker-divorce-courtadmin").build()
+            })
             .userGroup(UserCode.builder().code("caseworker").build())
             .build();
 

--- a/test-support/src/main/java/uk/gov/hmcts/reform/divorce/support/auth/IdamUserSupport.java
+++ b/test-support/src/main/java/uk/gov/hmcts/reform/divorce/support/auth/IdamUserSupport.java
@@ -1,22 +1,29 @@
 package uk.gov.hmcts.reform.divorce.support.auth;
 
 import io.restassured.RestAssured;
+import io.restassured.response.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.divorce.support.auth.model.CreateUserRequest;
+import uk.gov.hmcts.reform.divorce.support.auth.model.UserCode;
+import uk.gov.hmcts.reform.divorce.support.util.ResourceLoader;
 
 import java.util.Base64;
+import java.util.Locale;
 import java.util.UUID;
 
 @Service
 public class IdamUserSupport {
 
-    private static final String idamCaseworkerUser = "CaseWorkerTest";
-
-    private static final String idamCaseworkerPw = "password";
-
     @Value("${auth.idam.client.baseUrl}")
     private String idamUserBaseUrl;
+
+    @Value("${auth.idam.client.redirectUri}")
+    private String idamRedirectUri;
+
+    @Value("${auth.idam.client.secret}")
+    private String idamSecret;
 
     private String idamUsername;
 
@@ -28,7 +35,7 @@ public class IdamUserSupport {
 
     public String generateNewUserAndReturnToken() {
         String username = "simulate-delivered" + UUID.randomUUID() + "@notifications.service.gov.uk";
-        String password = UUID.randomUUID().toString();
+        String password = UUID.randomUUID().toString().toUpperCase(Locale.UK);
         createUserInIdam(username, password);
         return generateUserTokenWithNoRoles(username, password);
     }
@@ -47,18 +54,28 @@ public class IdamUserSupport {
 
     public synchronized String getIdamTestCaseWorkerUser() {
         if (StringUtils.isBlank(testCaseworkerJwtToken)) {
-            createCaseworkerUserInIdam();
-            testCaseworkerJwtToken = generateUserTokenWithNoRoles(idamCaseworkerUser, idamCaseworkerPw);
+            String username = "simulate-delivered" + UUID.randomUUID() + "@notifications.service.gov.uk";
+            String password = UUID.randomUUID().toString().toUpperCase(Locale.UK);
+            createCaseworkerUserInIdam(username, password);
+            testCaseworkerJwtToken = generateUserTokenWithNoRoles(username, password);
         }
 
         return testCaseworkerJwtToken;
     }
 
     private void createUserInIdam(String username, String password) {
+        CreateUserRequest userRequest = CreateUserRequest.builder()
+            .email(username)
+            .password(password)
+            .forename("Test")
+            .surname("User")
+            .roles(new UserCode[] { UserCode.builder().code("citizen").build() })
+            .userGroup(UserCode.builder().code("divorce-private-beta").build())
+            .build();
+
         RestAssured.given()
             .header("Content-Type", "application/json")
-            .body("{\"email\":\"" + username + "\", \"forename\":\"Test\",\"surname\":\"User\",\"password\":\""
-                + password + "\"}")
+            .body(ResourceLoader.objectToJson(userRequest))
             .post(idamCreateUrl());
     }
 
@@ -69,14 +86,20 @@ public class IdamUserSupport {
         createUserInIdam(idamUsername, idamPassword);
     }
 
-    private void createCaseworkerUserInIdam() {
+    private void createCaseworkerUserInIdam(String username, String password) {
+        CreateUserRequest userRequest = CreateUserRequest.builder()
+            .email(username)
+            .password(password)
+            .forename("Test")
+            .surname("User")
+            .roles(new UserCode[] { UserCode.builder().code("caseworker-divorce-courtadmin").build() })
+            .userGroup(UserCode.builder().code("caseworker").build())
+            .build();
+
         RestAssured.given()
-                .header("Content-Type", "application/json")
-                .body("{\"email\":\"" + idamCaseworkerUser + "\", "
-                        + "\"forename\":\"CaseWorkerTest\",\"surname\":\"User\",\"password\":\""
-                    + idamCaseworkerPw + "\", " + "\"roles\":[\"caseworker-divorce-courtadmin\"],"
-                    + " \"userGroup\":{\"code\":\"caseworker\"}}")
-                .post(idamCreateUrl());
+            .header("Content-Type", "application/json")
+            .body(ResourceLoader.objectToJson(userRequest))
+            .post(idamCreateUrl());
     }
 
     private String idamCreateUrl() {
@@ -84,14 +107,40 @@ public class IdamUserSupport {
     }
 
     private String generateUserTokenWithNoRoles(String username, String password) {
-        final String encoded = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
-        final String token = RestAssured.given().baseUri(idamUserBaseUrl)
-            .header("Authorization", "Basic " + encoded)
-            .post("/oauth2/authorize?response_type=token&client_id=divorce.support&redirect_uri="
-                + "https://www.preprod.ccd.reform.hmcts.net/oauth2redirect")
-            .body()
-            .path("access-token");
+        String userLoginDetails = String.join(":", username, password);
+        final String authHeader = "Basic " + new String(Base64.getEncoder().encode(userLoginDetails.getBytes()));
 
+        Response response = RestAssured.given()
+            .header("Authorization", authHeader)
+            .relaxedHTTPSValidation()
+            .post(idamCodeUrl());
+
+        if (response.getStatusCode() >= 300) {
+            throw new IllegalStateException("Token generation failed with code: " + response.getStatusCode()
+                + " body: " + response.getBody().prettyPrint());
+        }
+
+        response = RestAssured.given()
+            .relaxedHTTPSValidation()
+            .post(idamTokenUrl(response.getBody().path("code")));
+
+        String token = response.getBody().path("access_token");
         return "Bearer " + token;
+    }
+
+    private String idamCodeUrl() {
+        return idamUserBaseUrl + "/oauth2/authorize"
+            + "?response_type=code"
+            + "&client_id=divorce"
+            + "&redirect_uri=" + idamRedirectUri;
+    }
+
+    private String idamTokenUrl(String code) {
+        return idamUserBaseUrl + "/oauth2/token"
+            + "?code=" + code
+            + "&client_id=divorce"
+            + "&client_secret=" + idamSecret
+            + "&redirect_uri=" + idamRedirectUri
+            + "&grant_type=authorization_code";
     }
 }

--- a/test-support/src/main/java/uk/gov/hmcts/reform/divorce/support/auth/model/CreateUserRequest.java
+++ b/test-support/src/main/java/uk/gov/hmcts/reform/divorce/support/auth/model/CreateUserRequest.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.divorce.support.auth.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class CreateUserRequest {
+    private String email;
+    private String password;
+    private String forename;
+    private String surname;
+    private UserCode[] roles;
+    private UserCode userGroup;
+}

--- a/test-support/src/main/java/uk/gov/hmcts/reform/divorce/support/auth/model/UserCode.java
+++ b/test-support/src/main/java/uk/gov/hmcts/reform/divorce/support/auth/model/UserCode.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.divorce.support.auth.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class UserCode {
+    private String code;
+}

--- a/test-support/src/main/java/uk/gov/hmcts/reform/divorce/support/util/ResourceLoader.java
+++ b/test-support/src/main/java/uk/gov/hmcts/reform/divorce/support/util/ResourceLoader.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.divorce.support.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -18,5 +20,21 @@ public class ResourceLoader {
         }
 
         return Files.readAllBytes(Paths.get(url.toURI()));
+    }
+
+    public static <T> T loadJsonToObject(String filePath, Class<T> type) {
+        try {
+            return new ObjectMapper().readValue(loadAsText(filePath), type);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> String objectToJson(T object) {
+        try {
+            return new ObjectMapper().writeValueAsString(object);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
Integration tests currently are incompatible with SIDAM. These changes had been tested to an extent during SIDAM AAT Testing phase but was never merged. These changes should still be compatible with TIDAM.

Will be refactoring into a common auth library as part of the future. This is a quick fix to prepare for SIDAM.